### PR TITLE
Switch to `Array.from` instead of `slice`

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -205,7 +205,7 @@ function renderBlock(block, index, rawDraftObject, options) {
   }
 
   // Render text within content, along with any inline styles/entities
-  Array.prototype.slice.apply(block.text).some(function (character, characterIndex) {
+  Array.from(block.text).some(function (character, characterIndex) {
     var initialMarkdownStringLength = markdownString.length;
     markdownString = markdownString.replace(SINGLE_SPACE_CHARACTER, '');
     var newMarkdownStringLength = markdownString.length;


### PR DESCRIPTION
Switching because of issues with emoji when using slice,
https://mathiasbynens.be/notes/javascript-unicode talks about this a bit.