### PR TITLE
add block data support

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -194,7 +194,7 @@ function renderBlock(block, index, rawDraftObject, options) {
 
   // Render main block wrapping element
   if (customStyleItems[type] || StyleItems[type]) {
-    markdownString += (customStyleItems[type] || StyleItems[type]).open();
+    markdownString += (customStyleItems[type] || StyleItems[type]).open(block);
   }
 
   // Render text within content, along with any inline styles/entities
@@ -292,7 +292,7 @@ function renderBlock(block, index, rawDraftObject, options) {
 
   // Close block level item
   if (customStyleItems[type] || StyleItems[type]) {
-    markdownString += (customStyleItems[type] || StyleItems[type]).close();
+    markdownString += (customStyleItems[type] || StyleItems[type]).close(block);
   }
 
   // Determine how many newlines to add - generally we want 2, but for list items we just want one when they are succeeded by another list item.

--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -1,65 +1,55 @@
 const Remarkable = require('remarkable');
 // Block level items, key is Remarkable's key for them, value returned is
-// A function that generates the raw draftjs key.
+// A function that generates the raw draftjs key and block data.
 //
 // Why a function? Because in some cases (headers) we need additional information
-// before we can determine the exact key to return.
+// before we can determine the exact key to return. And blocks may also return data
 const DefaultBlockTypes = {
   paragraph_open: function (item) {
-    return 'unstyled';
+    return {
+      type: 'unstyled'
+    };
   },
 
   blockquote_open: function (item) {
-    return 'blockquote';
+    return {
+      type: 'blockquote'
+    };
   },
 
   ordered_list_item_open: function () {
-    return 'ordered-list-item';
+    return {
+      type: 'ordered-list-item'
+    };
   },
 
   unordered_list_item_open: function () {
-    return 'unordered-list-item';
+    return {
+      type: 'unordered-list-item'
+    };
   },
 
   fence: function () {
-    return 'code-block';
+    return {
+      type: 'code-block'
+    };
   },
 
   heading_open: function (item) {
-    var string = 'header-';
-    switch (item.hLevel) {
-      case 1:
-        string += 'one';
-        break;
+    var type = 'header-' + ({
+      1: 'one',
+      2: 'two',
+      3: 'three',
+      4: 'four',
+      5: 'five',
+      6: 'six'
+    })[item.hLevel];
 
-      case 2:
-        string += 'two';
-        break;
-
-      case 3:
-        string += 'three';
-        break;
-
-      case 4:
-        string += 'four';
-        break;
-
-      case 5:
-        string += 'five';
-        break;
-
-      case 6:
-        string += 'six';
-        break;
-    }
-
-    return string;
+    return {
+      type: type
+    };
   }
 };
-
-// Block level items, key is Remarkable's key for them, value returned is
-// A function that generates the raw block data.
-const DefaultBlockData = {}
 
 // Entity types. These are things like links or images that require
 // additional data and will be added to the `entityMap`
@@ -174,7 +164,6 @@ function markdownToDraft(string, options = {}) {
 
   // Allow user to define custom BlockTypes and Entities if they so wish
   const BlockTypes = Object.assign({}, DefaultBlockTypes, options.blockTypes || {});
-  const BlockData = Object.assign({}, DefaultBlockData, options.blockData || {});
   const BlockEntities = Object.assign({}, DefaultBlockEntities, options.blockEntities || {});
   const BlockStyles = Object.assign({}, DefaultBlockStyles, options.blockStyles || {});
 
@@ -209,14 +198,9 @@ function markdownToDraft(string, options = {}) {
       // TODO: Draft does allow lists to be nested within lists, it's the one exception to its rule,
       // but right now this code doesn't support that.
       if (item.level === 0 || item.type === 'list_item_open') {
-        var block = {
-          type: BlockTypes[itemType](item),
+        var block = Object.assign({
           depth: 0
-        };
-
-        if (BlockData[itemType]) {
-          block.data = BlockData[itemType](item)
-        }
+        }, BlockTypes[itemType](item))
 
         // Sigh edgecases.
         // Fence block doesn't have any inline children so we have to apply the content directly,

--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -57,6 +57,10 @@ const DefaultBlockTypes = {
   }
 };
 
+// Block level items, key is Remarkable's key for them, value returned is
+// A function that generates the raw block data.
+const DefaultBlockData = {}
+
 // Entity types. These are things like links or images that require
 // additional data and will be added to the `entityMap`
 // again. In this case, key is remarkable key, value is
@@ -170,6 +174,7 @@ function markdownToDraft(string, options = {}) {
 
   // Allow user to define custom BlockTypes and Entities if they so wish
   const BlockTypes = Object.assign({}, DefaultBlockTypes, options.blockTypes || {});
+  const BlockData = Object.assign({}, DefaultBlockData, options.blockData || {});
   const BlockEntities = Object.assign({}, DefaultBlockEntities, options.blockEntities || {});
   const BlockStyles = Object.assign({}, DefaultBlockStyles, options.blockStyles || {});
 
@@ -208,6 +213,10 @@ function markdownToDraft(string, options = {}) {
           type: BlockTypes[itemType](item),
           depth: 0
         };
+
+        if (BlockData[itemType]) {
+          block.data = BlockData[itemType](item)
+        }
 
         // Sigh edgecases.
         // Fence block doesn't have any inline children so we have to apply the content directly,

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -106,4 +106,26 @@ describe('draftToMarkdown', function () {
 
     expect(markdown).toEqual('<span style="color: red">One</span><span style="color: orange">Two</span><span style="color: yellow">Three</span>')
   });
+
+  it('allows to retrieve block data', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"fb5f8","text":"","type":"atomic:image","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{"src":"https://example.com"}}]}
+    /* eslint-enable */
+    var markdown = draftToMarkdown(rawObject, {
+      styleItems: {
+        'atomic:image': {
+          open: (block) => {
+            const alt = block.data.alt || ''
+            const title = block.data.title
+              ? ` "${block.data.title}"`
+              : ''
+            return `![${alt}](${block.data.src}${title})`
+          },
+          close: () => ''
+        }
+      }
+    })
+
+    expect(markdown).toEqual('![](https://example.com)')
+  })
 });

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -151,10 +151,13 @@ describe('markdownToDraft', function () {
   it('can handle block data', function () {
     var markdown = '```js\ntest()\n```';
     var conversionResult = markdownToDraft(markdown, {
-      blockData: {
+      blockTypes: {
         fence: function (item) {
           return {
-            lang: item.params
+            type: 'code-block',
+            data: {
+              lang: item.params
+            }
           }
         }
       }

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -74,7 +74,7 @@ describe('markdownToDraft', function () {
     expect(conversionResult.blocks[7].entityRanges).toEqual([]);
   });
 
-  it('can handle custom data', function () {
+  it('can handle block entity data', function () {
     const MentionRegexp = /^@\[([^\]]*)\]\s*\(([^)]+)\)/;
     function mentionWrapper(remarkable) {
       remarkable.inline.ruler.push('mention', function mention(state, silent) {
@@ -147,4 +147,20 @@ describe('markdownToDraft', function () {
     expect(conversionResult.entityMap[blockOneKey].data.id).toEqual('1');
     expect(conversionResult.entityMap[blockOneKey].data.name).toEqual('Rose');
   });
+
+  it('can handle block data', function () {
+    var markdown = '```js\ntest()\n```';
+    var conversionResult = markdownToDraft(markdown, {
+      blockData: {
+        fence: function (item) {
+          return {
+            lang: item.params
+          }
+        }
+      }
+    });
+
+    expect(conversionResult.blocks[0].type).toEqual('code-block');
+    expect(conversionResult.blocks[0].data.lang).toEqual('js');
+  })
 });


### PR DESCRIPTION
[RawDraftContentBlock can have data](https://github.com/facebook/draft-js/blob/master/src/model/encoding/RawDraftContentBlock.js#L30).

[medium-draft](https://github.com/brijeshb42/medium-draft) uses blocks for images so I need to access the block data (and a crazy remarkable block rule to get images as blocks).

But there also seem to be some other use cases for block data, for example a code block with params.