### PR TITLE
Fix issue with empty headings and blockquotes

### DIFF
--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -13,7 +13,8 @@ const DefaultBlockTypes = {
 
   blockquote_open: function (item) {
     return {
-      type: 'blockquote'
+      type: 'blockquote',
+      text: ''
     };
   },
 
@@ -49,7 +50,8 @@ const DefaultBlockTypes = {
     })[item.hLevel];
 
     return {
-      type: type
+      type: type,
+      text: ''
     };
   }
 };

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -165,5 +165,21 @@ describe('markdownToDraft', function () {
 
     expect(conversionResult.blocks[0].type).toEqual('code-block');
     expect(conversionResult.blocks[0].data.lang).toEqual('js');
-  })
+  });
+
+  it('can handle an empty heading', function () {
+    var markdown = '#';
+    var conversionResult = markdownToDraft(markdown);
+
+    expect(conversionResult.blocks[0].type).toEqual('header-one');
+    expect(conversionResult.blocks[0].text).toEqual('');
+  });
+
+  it('can handle an empty blockquote', function () {
+    var markdown = '>';
+    var conversionResult = markdownToDraft(markdown);
+
+    expect(conversionResult.blocks[0].type).toEqual('blockquote');
+    expect(conversionResult.blocks[0].text).toEqual('');
+  });
 });


### PR DESCRIPTION
As reported here: https://github.com/Rosey/markdown-draft-js/issues/17

DraftJS `convertFromRaw` expects headings and blockquotes to always have `text`
defined, which was not the case if the markdown string was something like a
single `#` or `>`.

By defining the text value by default to be an empty string, we get around this
issue, and the empty string will under normal circumstances still be replaced by
the proper content if there is any.