### PR TITLE
Fix bugginess when converting draftjs trailing whitespace to markdown

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -1,4 +1,4 @@
-const SINGLE_SPACE_CHARACTER = /\u0020*$/;
+const TRAILING_WHITESPACE = /[ |\u0020|\t]*$/;
 
 // A map of draftjs block types -> markdown open and close characters
 // Both the open and close methods must exist, even if they simply return an empty string.
@@ -199,11 +199,6 @@ function renderBlock(block, index, rawDraftObject, options) {
 
   // Render text within content, along with any inline styles/entities
   Array.from(block.text).some(function (character, characterIndex) {
-    var initialMarkdownStringLength = markdownString.length;
-    markdownString = markdownString.replace(SINGLE_SPACE_CHARACTER, '');
-    var newMarkdownStringLength = markdownString.length;
-    var totalSpacesToReadd = initialMarkdownStringLength - newMarkdownStringLength;
-
     // Close any entity tags that need closing
     block.entityRanges.forEach(function (range, rangeIndex) {
       if (range.offset + range.length === characterIndex) {
@@ -224,13 +219,21 @@ function renderBlock(block, index, rawDraftObject, options) {
             for (var i = openInlineStyles.length - 1; i !== styleIndex; i--) {
               var styleItem = (customStyleItems[openInlineStyles[i].style] || StyleItems[openInlineStyles[i].style]);
               if (styleItem) {
+                var trailingWhitespace = TRAILING_WHITESPACE.exec(markdownString);
+                markdownString = markdownString.slice(0, markdownString.length - trailingWhitespace[0].length);
                 markdownString += styleItem.close();
+                markdownString += trailingWhitespace[0];
               }
             }
           }
 
           // Close the actual inline style being closed
+          // Have to trim whitespace first and then re-add after because markdown can't handle leading/trailing whitespace
+          var trailingWhitespace = TRAILING_WHITESPACE.exec(markdownString);
+          markdownString = markdownString.slice(0, markdownString.length - trailingWhitespace[0].length);
+
           markdownString += (customStyleItems[style.style] || StyleItems[style.style]).close();
+          markdownString += trailingWhitespace[0];
 
           // Handle nested case - reopen any inline styles after closing the parent
           if (styleIndex > -1 && styleIndex !== openInlineStyles.length - 1) {
@@ -246,11 +249,6 @@ function renderBlock(block, index, rawDraftObject, options) {
         }
       }
     });
-
-    // We removed trailing whitespace before closing markdown tags because
-    // markdown doesn't play nice with trailing whitespace.
-    // But we want to preserve it, so we re-add it after closing all tags.
-    markdownString += ' '.repeat(totalSpacesToReadd);
 
     // Open any inline tags that need opening
     block.inlineStyleRanges.forEach(function (style, styleIndex) {
@@ -287,7 +285,10 @@ function renderBlock(block, index, rawDraftObject, options) {
 
   // Close any remaining inline tags (if an inline tag ends at the very last char, we won't catch it inside the loop)
   openInlineStyles.reverse().forEach(function (style) {
+    var trailingWhitespace = TRAILING_WHITESPACE.exec(markdownString);
+    markdownString = markdownString.slice(0, markdownString.length - trailingWhitespace[0].length);
     markdownString += (customStyleItems[style.style] || StyleItems[style.style]).close();
+    markdownString += trailingWhitespace[0];
   });
 
   // Close block level item

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -1,6 +1,33 @@
 import { markdownToDraft, draftToMarkdown } from '../src/index';
 
 describe('draftToMarkdown', function () {
+  it('renders inline styled text with trailing whitespace correctly', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"Test Bold Text Test","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":5,"length":10,"style":"BOLD"}],"entityRanges":[],"data":{}}]};
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('Test **Bold Text** Test');
+  });
+
+  it('renders inline styled text with trailing whitespace correctly when trailing whitespace is the last character', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"Test Bold Text ","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":5,"length":10,"style":"BOLD"}],"entityRanges":[],"data":{}}]};
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('Test **Bold Text** ');
+  });
+
+  it('renders nested inline styled text with trailing whitespace correctly', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"Test Bold Text Test","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":10,"style":"ITALIC"},{"offset":5,"length":9,"style":"BOLD"}],"entityRanges":[],"data":{}}]};
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('_Test **Bold**_ **Text** Test');
+  });
+
   it('renders links correctly', function () {
     /* eslint-disable */
     var rawObject = {"entityMap":{"0":{"type":"LINK","mutability":"MUTABLE","data":{"url":"https://google.com"}},"1":{"type":"LINK","mutability":"MUTABLE","data":{"url":"https://facebook.github.io/draft-js/"}}},"blocks":[{"key":"58spd","text":"This is a test of a link","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":18,"length":6,"key":0}],"data":{}},{"key":"9ln6g","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"3euar","text":"And perhaps we should test once more.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":4,"length":7,"key":1}],"data":{}}]};


### PR DESCRIPTION
There was some code in place for this but it wasn't working in all
cases. For inline styles like italic and bold, markdown doesn't play
nice when the final few characters are whitepsace, so this checks for
that and cuts it out, adds the closing markdown character, and _then_
re-adds the trailing whitespace.

----

⭐️  Note: I'm going to have to add another PR to handle a related-but-different case that can happen: Leading WS. Markdown is equally unhappy with something like `** Test**`  but this current PR only checks for `**Test **`