### PR TITLE
Fix bug with draft-to-markdown leading whitespace

### DIFF
--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -1,6 +1,15 @@
 import { markdownToDraft, draftToMarkdown } from '../src/index';
 
 describe('draftToMarkdown', function () {
+  it('renders inline styled text with leading whitespace correctly', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"Test Bold Text Test","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":4,"length":10,"style":"BOLD"}],"entityRanges":[],"data":{}}]};
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('Test **Bold Text** Test');
+  });
+
   it('renders inline styled text with trailing whitespace correctly', function () {
     /* eslint-disable */
     var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"Test Bold Text Test","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":5,"length":10,"style":"BOLD"}],"entityRanges":[],"data":{}}]};


### PR DESCRIPTION
Because markdown doesn't work when there's leading whitespace we need to
trim it off the front.

Approach here is to hang on to styles to add and not actually add them
until we hit a non-whitespace character.