### PR TITLE
Fix reopening of inline styles

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -211,7 +211,7 @@ function renderBlock(block, index, rawDraftObject, options) {
     });
 
     // Close any inline tags that need closing
-    block.inlineStyleRanges.forEach(function (style, styleIndex) {
+    openInlineStyles.forEach(function (style, styleIndex) {
       if (style.offset + style.length === characterIndex) {
         if ((customStyleItems[style.style] || StyleItems[style.style])) {
           var styleIndex = openInlineStyles.indexOf(style);
@@ -240,8 +240,10 @@ function renderBlock(block, index, rawDraftObject, options) {
           if (styleIndex > -1 && styleIndex !== openInlineStyles.length - 1) {
             for (var i = openInlineStyles.length - 1; i !== styleIndex; i--) {
               var styleItem = (customStyleItems[openInlineStyles[i].style] || StyleItems[openInlineStyles[i].style]);
-              if (styleItem) {
+              if (styleItem && openInlineStyles[i].offset + openInlineStyles[i].length > characterIndex) {
                 markdownString += styleItem.open();
+              } else {
+                openInlineStyles.splice(i, 1);
               }
             }
           }


### PR DESCRIPTION
This is an additional fix on top of https://github.com/Rosey/markdown-draft-js/pull/3.

Rich text

**_bold/italic_** plain

Expected markdown

`**_bold/italic_** plain`

Actual markdown

`**_bold/italic_**__ plain`