### PR TITLE
Fix markdown stripping blank paragraphs/newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ var rawDraftJSObject = markdownToDraft(markdownString, {
 });
 ```
 
+
+## Additional options
+
+### Remarkable options
+
 Since this module uses remarkable under the hood, you can also pass down options for the remarkable parser, simply add the property `remarkableOptions` to your options object. For example, let's say you wanted to parse html as well:
 
 ```javascript
@@ -114,3 +119,9 @@ var rawDraftJSObject = markdownToDraft(markdownString, {
   }
 });
 ```
+
+### More options
+
+`preserveNewlines` can be passed in to preserve empty whitespace newlines. By default, markdown rules specify that blank whitespace is collapsed, but in the interest in maintaining 1:1 parity with draft appearance-wise, this option can be turned on if you like :)  
+
+NOTE: If you plan on passing the markdown to a 3rd party markdown parser, markdown default behaviour IS to strip additional newlines, so the HTML it generates will likely strip those newlines at that point.... Which is why this is an option disabled by default.

--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -333,7 +333,11 @@ function renderBlock(block, index, rawDraftObject, options) {
   if (SingleNewlineAfterBlock.indexOf(type) !== -1 && rawDraftObject.blocks[index + 1] && SingleNewlineAfterBlock.indexOf(rawDraftObject.blocks[index + 1].type) !== -1) {
     markdownString += '\n';
   } else if (rawDraftObject.blocks[index + 1]) {
-    markdownString += '\n\n';
+    if (rawDraftObject.blocks[index].text) {
+      markdownString += '\n\n';
+    } else if (options.preserveNewlines) {
+      markdownString += '\n';
+    }
   }
 
   return markdownString;

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -49,7 +49,7 @@ describe('draftToMarkdown', function () {
     var rawObject = {"entityMap":{"0":{"type":"LINK","mutability":"MUTABLE","data":{"url":"https://google.com"}},"1":{"type":"LINK","mutability":"MUTABLE","data":{"url":"https://facebook.github.io/draft-js/"}}},"blocks":[{"key":"58spd","text":"This is a test of a link","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":18,"length":6,"key":0}],"data":{}},{"key":"9ln6g","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"3euar","text":"And perhaps we should test once more.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":4,"length":7,"key":1}],"data":{}}]};
     /* eslint-enable */
     var markdown = draftToMarkdown(rawObject);
-    expect(markdown).toEqual('This is a test of [a link](https://google.com)\n\n\n\nAnd [perhaps](https://facebook.github.io/draft-js/) we should test once more.');
+    expect(markdown).toEqual('This is a test of [a link](https://google.com)\n\nAnd [perhaps](https://facebook.github.io/draft-js/) we should test once more.');
   });
 
   it('renders "the kitchen sink" correctly', function () {

--- a/test/idempotency.spec.js
+++ b/test/idempotency.spec.js
@@ -14,6 +14,15 @@ import { markdownToDraft, draftToMarkdown } from '../src/index';
 */
 
 describe('idempotency', function () {
+
+  it('renders new lines text correctly', function () {
+    var markdownString = 'Test\n\n\nHello There\n\nSmile\n\n\n\n\n\n\n\nYep Hi';
+    var draftJSObject = markdownToDraft(markdownString, {preserveNewlines: true});
+    var markdownFromDraft = draftToMarkdown(draftJSObject, {preserveNewlines: true});
+
+    expect(markdownFromDraft).toEqual(markdownString);
+  });
+
   it('renders italic text correctly', function () {
     var markdownString = '_I am italic_ …I am not italic.';
     var draftJSObject = markdownToDraft(markdownString);

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -1,15 +1,15 @@
 import { markdownToDraft, draftToMarkdown } from '../src/index';
 
 describe('markdownToDraft', function () {
+  it('renders empty text correctly', function () {
+    var markdown = '';
+    var conversionResult = markdownToDraft(markdown);
+
+    expect(conversionResult.blocks[0].text).toEqual('');
+    expect(conversionResult.blocks[0].type).toEqual('unstyled');
+  });
+
   describe ('codeblocks', function () {
-    it('renders empty text correctly', function () {
-      var markdown = '';
-      var conversionResult = markdownToDraft(markdown);
-
-      expect(conversionResult.blocks[0].text).toEqual('');
-      expect(conversionResult.blocks[0].type).toEqual('unstyled');
-    });
-
     it ('renders single-line codeblock correctly', function () {
       var markdown = '```\nsingle line codeblock\n```';
       var conversionResult = markdownToDraft(markdown);


### PR DESCRIPTION
This is an option that can be turned on if you want 1:1 parity with
draftjs as far as newlines go.

By default, markdown's rules state that multiple newlines are collapsed.

With this option turned on, when converting back and forth, they will NOT be.

However, it's worth noting that if you then decide to pass the  markdown
to a 3rd party to render it into HTML, unless that 3rd party's parser
has a similar option, the newlines will be collapsed at that point.

https://github.com/Rosey/markdown-draft-js/issues/37