### PR TITLE
Fix closing tags

### DIFF
--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -134,6 +134,8 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
     } else if (BlockEntities[child.type]) {
       var key = generateUniqueKey();
 
+      blockEntities[key] = BlockEntities[child.type](child);
+
       blockEntityRanges.push({
         offset: content.length || 0,
         length: 0,

--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -148,7 +148,7 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
       blockInlineStyleRanges = blockInlineStyleRanges
         .map(style => {
           if (style.length === 0 && style.style === type) {
-            style.length = content.length - blockInlineStyleRanges[blockInlineStyleRanges.length - 1].offset;
+            style.length = content.length - style.offset;
           }
           return style;
         });

--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -134,8 +134,6 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
     } else if (BlockEntities[child.type]) {
       var key = generateUniqueKey();
 
-      blockEntities[key] = BlockEntities[child.type](child);
-
       blockEntityRanges.push({
         offset: content.length || 0,
         length: 0,
@@ -144,7 +142,14 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
     } else if (child.type.indexOf('_close') !== -1 && BlockEntities[child.type.replace('_close', '_open')]) {
       blockEntityRanges[blockEntityRanges.length - 1].length = content.length - blockEntityRanges[blockEntityRanges.length - 1].offset;
     } else if (child.type.indexOf('_close') !== -1 && BlockStyles[child.type.replace('_close', '_open')]) {
-      blockInlineStyleRanges[blockInlineStyleRanges.length - 1].length = content.length - blockInlineStyleRanges[blockInlineStyleRanges.length - 1].offset;
+      var type = BlockStyles[child.type.replace('_close', '_open')]
+      blockInlineStyleRanges = blockInlineStyleRanges
+        .map(style => {
+          if (style.length === 0 && style.style === type) {
+            style.length = content.length - blockInlineStyleRanges[blockInlineStyleRanges.length - 1].offset;
+          }
+          return style;
+        });
     }
   });
 

--- a/test/idempotency.spec.js
+++ b/test/idempotency.spec.js
@@ -39,6 +39,14 @@ describe('idempotency', function () {
     expect(markdownFromDraft).toEqual(markdownString);
   });
 
+  it('renders nested styles correctly', function () {
+    var markdownString = '**bold** _italic_ test **bold _italic_** _italic_ _italic **bold** italic **bold italic**_';
+    var draftJSObject = markdownToDraft(markdownString);
+    var markdownFromDraft = draftToMarkdown(draftJSObject);
+
+    expect(markdownFromDraft).toEqual(markdownString);
+  });
+
   it('renders inline code correctly', function () {
     var markdownString = 'Test `here is some inline code`';
     var draftJSObject = markdownToDraft(markdownString);

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -259,4 +259,12 @@ describe('markdownToDraft', function () {
     expect(conversionResult.blocks[1].type).toEqual('ordered-list-item');
     expect(conversionResult.blocks[1].depth).toEqual(1);
   });
+
+  it('can handle nested styles', function () {
+    var markdown = '__*hello* world__';
+    var conversionResult = markdownToDraft(markdown);
+
+    expect(conversionResult.blocks[0].inlineStyleRanges[0].length).toBe(11);
+    expect(conversionResult.blocks[0].inlineStyleRanges[1].length).toBe(5);
+  });
 });

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -260,7 +260,7 @@ describe('markdownToDraft', function () {
     expect(conversionResult.blocks[1].depth).toEqual(1);
   });
 
-  fit('can handle nested styles', function () {
+  it('can handle nested styles', function () {
     var markdown = '__*hello* world__';
     var conversionResult = markdownToDraft(markdown);
 
@@ -270,8 +270,36 @@ describe('markdownToDraft', function () {
     markdown = '**bold _bolditalic_** _italic_ regular';
     conversionResult = markdownToDraft(markdown);
 
-    // Expected ouput in comment -
-    // {"entityMap":{},"blocks":[{"key":"adnm7","text":"bold bolditalic italic regular","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":16,"style":"BOLD"},{"offset":5,"length":17,"style":"ITALIC"}],"entityRanges":[],"data":{}}]}
+    // Expected ouput in comment below.
+    // because markdown forces you to close and re-open when nesting, and draft doesn't, I don't know if this exact expected output is realistic
+    // or if it should actually more closesly match how markdown works. May be easier to more closely match markdown, so long as the appearance is the same
+    // Currently the output given doesn't have the correct styling appearance-wise. You can also see this in the 'renders nested styles correctly' test added to idempotency
+    // {
+    //    "entityMap" : {},
+    //    "blocks" : [
+    //       {
+    //          "depth" : 0,
+    //          "type" : "unstyled",
+    //          "key" : "adnm7",
+    //          "inlineStyleRanges" : [
+    //             {
+    //                "offset" : 0,
+    //                "length" : 16,
+    //                "style" : "BOLD"
+    //             },
+    //             {
+    //                "style" : "ITALIC",
+    //                "length" : 17,
+    //                "offset" : 5
+    //             }
+    //          ],
+    //          "data" : {},
+    //          "text" : "bold bolditalic italic regular",
+    //          "entityRanges" : []
+    //       }
+    //    ]
+    // }
+
     expect(conversionResult.blocks[0].inlineStyleRanges[0].offset).toEqual(0);
     expect(conversionResult.blocks[0].inlineStyleRanges[0].length).toEqual(16);
     expect(conversionResult.blocks[0].inlineStyleRanges[1].offset).toEqual(5);

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -260,11 +260,22 @@ describe('markdownToDraft', function () {
     expect(conversionResult.blocks[1].depth).toEqual(1);
   });
 
-  it('can handle nested styles', function () {
+  fit('can handle nested styles', function () {
     var markdown = '__*hello* world__';
     var conversionResult = markdownToDraft(markdown);
 
     expect(conversionResult.blocks[0].inlineStyleRanges[0].length).toBe(11);
     expect(conversionResult.blocks[0].inlineStyleRanges[1].length).toBe(5);
+
+    markdown = '**bold _bolditalic_** _italic_ regular';
+    conversionResult = markdownToDraft(markdown);
+
+    // Expected ouput in comment -
+    // {"entityMap":{},"blocks":[{"key":"adnm7","text":"bold bolditalic italic regular","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":0,"length":16,"style":"BOLD"},{"offset":5,"length":17,"style":"ITALIC"}],"entityRanges":[],"data":{}}]}
+    expect(conversionResult.blocks[0].inlineStyleRanges[0].offset).toEqual(0);
+    expect(conversionResult.blocks[0].inlineStyleRanges[0].length).toEqual(16);
+    expect(conversionResult.blocks[0].inlineStyleRanges[1].offset).toEqual(5);
+    expect(conversionResult.blocks[0].inlineStyleRanges[1].length).toEqual(17);
+    expect(conversionResult.blocks[0].text).toEqual('bold bolditalic italic regular');
   });
 });

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -260,50 +260,46 @@ describe('markdownToDraft', function () {
     expect(conversionResult.blocks[1].depth).toEqual(1);
   });
 
-  it('can handle nested styles', function () {
+  it('can handle simple nested styles', function () {
     var markdown = '__*hello* world__';
     var conversionResult = markdownToDraft(markdown);
 
     expect(conversionResult.blocks[0].inlineStyleRanges[0].length).toBe(11);
     expect(conversionResult.blocks[0].inlineStyleRanges[1].length).toBe(5);
 
-    markdown = '**bold _bolditalic_** _italic_ regular';
-    conversionResult = markdownToDraft(markdown);
+  });
 
-    // Expected ouput in comment below.
-    // because markdown forces you to close and re-open when nesting, and draft doesn't, I don't know if this exact expected output is realistic
-    // or if it should actually more closesly match how markdown works. May be easier to more closely match markdown, so long as the appearance is the same
-    // Currently the output given doesn't have the correct styling appearance-wise. You can also see this in the 'renders nested styles correctly' test added to idempotency
-    // {
-    //    "entityMap" : {},
-    //    "blocks" : [
-    //       {
-    //          "depth" : 0,
-    //          "type" : "unstyled",
-    //          "key" : "adnm7",
-    //          "inlineStyleRanges" : [
-    //             {
-    //                "offset" : 0,
-    //                "length" : 16,
-    //                "style" : "BOLD"
-    //             },
-    //             {
-    //                "style" : "ITALIC",
-    //                "length" : 17,
-    //                "offset" : 5
-    //             }
-    //          ],
-    //          "data" : {},
-    //          "text" : "bold bolditalic italic regular",
-    //          "entityRanges" : []
-    //       }
-    //    ]
-    // }
+  it('can handle more complex nested styles', function () {
+    var markdown = '**bold _bolditalic_** _italic_ regular';
+    var conversionResult = markdownToDraft(markdown);
 
-    expect(conversionResult.blocks[0].inlineStyleRanges[0].offset).toEqual(0);
-    expect(conversionResult.blocks[0].inlineStyleRanges[0].length).toEqual(16);
-    expect(conversionResult.blocks[0].inlineStyleRanges[1].offset).toEqual(5);
-    expect(conversionResult.blocks[0].inlineStyleRanges[1].length).toEqual(17);
-    expect(conversionResult.blocks[0].text).toEqual('bold bolditalic italic regular');
+    expect(conversionResult).toEqual({
+      'entityMap': {},
+      'blocks': [
+        {
+          'depth': 0,
+          'type': 'unstyled',
+          'text': 'bold bolditalic italic regular',
+          'entityRanges': [],
+          'inlineStyleRanges': [
+            {
+              'offset': 0,
+              'length': 15,
+              'style': 'BOLD'
+            },
+            {
+              'offset': 5,
+              'length': 10,
+              'style': 'ITALIC'
+            },
+            {
+              'offset': 16,
+              'length': 6,
+              'style': 'ITALIC'
+            }
+          ]
+        }
+      ]
+    });
   });
 });


### PR DESCRIPTION
Before this - markdown with nested styles couldn't be properly rendered.

Before this - the last tag would always be assumed as the closing tag, so if there's more than 1 open tag, the logic would fail, the logic now checks for two things to assume a closing tag:

- if the closing tag matches the opening tag.
- If the length of the item is 0.

fixes #43