### PR TITLE
Fix closing tags

### DIFF
--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -144,7 +144,14 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
     } else if (child.type.indexOf('_close') !== -1 && BlockEntities[child.type.replace('_close', '_open')]) {
       blockEntityRanges[blockEntityRanges.length - 1].length = content.length - blockEntityRanges[blockEntityRanges.length - 1].offset;
     } else if (child.type.indexOf('_close') !== -1 && BlockStyles[child.type.replace('_close', '_open')]) {
-      blockInlineStyleRanges[blockInlineStyleRanges.length - 1].length = content.length - blockInlineStyleRanges[blockInlineStyleRanges.length - 1].offset;
+      var type = BlockStyles[child.type.replace('_close', '_open')]
+      blockInlineStyleRanges = blockInlineStyleRanges
+        .map(style => {
+          if (style.length === 0 && style.style === type) {
+            style.length = content.length - style.offset;
+          }
+          return style;
+        });
     }
   });
 

--- a/test/idempotency.spec.js
+++ b/test/idempotency.spec.js
@@ -39,6 +39,14 @@ describe('idempotency', function () {
     expect(markdownFromDraft).toEqual(markdownString);
   });
 
+  it('renders nested styles correctly', function () {
+    var markdownString = '**bold** _italic_ test **bold _italic_** _italic_ _italic **bold** italic **bold italic**_';
+    var draftJSObject = markdownToDraft(markdownString);
+    var markdownFromDraft = draftToMarkdown(draftJSObject);
+
+    expect(markdownFromDraft).toEqual(markdownString);
+  });
+
   it('renders inline code correctly', function () {
     var markdownString = 'Test `here is some inline code`';
     var draftJSObject = markdownToDraft(markdownString);

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -259,4 +259,47 @@ describe('markdownToDraft', function () {
     expect(conversionResult.blocks[1].type).toEqual('ordered-list-item');
     expect(conversionResult.blocks[1].depth).toEqual(1);
   });
+
+  it('can handle simple nested styles', function () {
+    var markdown = '__*hello* world__';
+    var conversionResult = markdownToDraft(markdown);
+
+    expect(conversionResult.blocks[0].inlineStyleRanges[0].length).toBe(11);
+    expect(conversionResult.blocks[0].inlineStyleRanges[1].length).toBe(5);
+
+  });
+
+  it('can handle more complex nested styles', function () {
+    var markdown = '**bold _bolditalic_** _italic_ regular';
+    var conversionResult = markdownToDraft(markdown);
+
+    expect(conversionResult).toEqual({
+      'entityMap': {},
+      'blocks': [
+        {
+          'depth': 0,
+          'type': 'unstyled',
+          'text': 'bold bolditalic italic regular',
+          'entityRanges': [],
+          'inlineStyleRanges': [
+            {
+              'offset': 0,
+              'length': 15,
+              'style': 'BOLD'
+            },
+            {
+              'offset': 5,
+              'length': 10,
+              'style': 'ITALIC'
+            },
+            {
+              'offset': 16,
+              'length': 6,
+              'style': 'ITALIC'
+            }
+          ]
+        }
+      ]
+    });
+  });
 });


### PR DESCRIPTION
Before this - markdown with nested styles couldn't be properly rendered.

Before this - the last tag would always be assumed as the closing tag, so if there's more than 1 open tag, the logic would fail, the logic now checks for two things to assume a closing tag:
- if the closing tag matches the opening tag.
- if the length of the item is 0.

----

Original PR: https://github.com/Rosey/markdown-draft-js/pull/42
Issue: https://github.com/Rosey/markdown-draft-js/issues/43