### PR TITLE
Fix handling of emoji

### DIFF
--- a/src/UnicodeUtils.js
+++ b/src/UnicodeUtils.js
@@ -1,11 +1,35 @@
+/*
+ * This is an almost verbatim copy of
+ *
+ * https://github.com/facebook/fbjs/blob/7da8335b78d669cba263760872f0a45ed16b4d12/packages/fbjs/src/unicode/UnicodeUtils.js
+ *
+ * It has been modified to remove `invariant` dependency and to embed the license directly.
+ */
+
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * MIT License
  *
- * @providesModule UnicodeUtils
- * @typechecks
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 /**
@@ -21,7 +45,18 @@
 
 'use strict';
 
-const invariant = require('invariant');
+const invariant = function (condition, format, a, b) {
+  if (!condition) {
+    const args = [a, b];
+    let argIndex = 0;
+    const error = new Error(
+      format.replace(/%s/g, function () { return args[argIndex++]; })
+    );
+    error.name = 'Invariant Violation';
+    error.framesToPop = 1;
+    throw error;
+  }
+}
 
 // These two ranges are consecutive so anything in [HIGH_START, LOW_END] is a
 // surrogate code unit.

--- a/src/UnicodeUtils.js
+++ b/src/UnicodeUtils.js
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule UnicodeUtils
+ * @typechecks
+ */
+
+/**
+ * Unicode-enabled replacesments for basic String functions.
+ *
+ * All the functions in this module assume that the input string is a valid
+ * UTF-16 encoding of a Unicode sequence. If it's not the case, the behavior
+ * will be undefined.
+ *
+ * WARNING: Since this module is typechecks-enforced, you may find new bugs
+ * when replacing normal String functions with ones provided here.
+ */
+
+'use strict';
+
+const invariant = require('invariant');
+
+// These two ranges are consecutive so anything in [HIGH_START, LOW_END] is a
+// surrogate code unit.
+const SURROGATE_HIGH_START  = 0xD800;
+const SURROGATE_HIGH_END    = 0xDBFF;
+const SURROGATE_LOW_START   = 0xDC00;
+const SURROGATE_LOW_END     = 0xDFFF;
+const SURROGATE_UNITS_REGEX = /[\uD800-\uDFFF]/;
+
+/**
+ * @param {number} codeUnit   A Unicode code-unit, in range [0, 0x10FFFF]
+ * @return {boolean}          Whether code-unit is in a surrogate (hi/low) range
+ */
+function isCodeUnitInSurrogateRange(codeUnit) {
+  return SURROGATE_HIGH_START <= codeUnit && codeUnit <= SURROGATE_LOW_END;
+}
+
+/**
+ * Returns whether the two characters starting at `index` form a surrogate pair.
+ * For example, given the string s = "\uD83D\uDE0A", (s, 0) returns true and
+ * (s, 1) returns false.
+ *
+ * @param {string} str
+ * @param {number} index
+ * @return {boolean}
+ */
+function isSurrogatePair(str, index) {
+  invariant(
+    0 <= index && index < str.length,
+    'isSurrogatePair: Invalid index %s for string length %s.',
+    index,
+    str.length
+  );
+  if (index + 1 === str.length) {
+    return false;
+  }
+  const first = str.charCodeAt(index);
+  const second = str.charCodeAt(index + 1);
+  return (
+    SURROGATE_HIGH_START <= first && first <= SURROGATE_HIGH_END &&
+    SURROGATE_LOW_START <= second && second <= SURROGATE_LOW_END
+  );
+}
+
+/**
+ * @param {string} str  Non-empty string
+ * @return {boolean}    True if the input includes any surrogate code units
+ */
+function hasSurrogateUnit(str) {
+  return SURROGATE_UNITS_REGEX.test(str);
+}
+
+/**
+ * Return the length of the original Unicode character at given position in the
+ * String by looking into the UTF-16 code unit; that is equal to 1 for any
+ * non-surrogate characters in BMP ([U+0000..U+D7FF] and [U+E000, U+FFFF]); and
+ * returns 2 for the hi/low surrogates ([U+D800..U+DFFF]), which are in fact
+ * representing non-BMP characters ([U+10000..U+10FFFF]).
+ *
+ * Examples:
+ * - '\u0020' => 1
+ * - '\u3020' => 1
+ * - '\uD835' => 2
+ * - '\uD835\uDDEF' => 2
+ * - '\uDDEF' => 2
+ *
+ * @param {string} str  Non-empty string
+ * @param {number} pos  Position in the string to look for one code unit
+ * @return {number}      Number 1 or 2
+ */
+function getUTF16Length(str, pos) {
+  return 1 + isCodeUnitInSurrogateRange(str.charCodeAt(pos));
+}
+
+/**
+ * Fully Unicode-enabled replacement for String#length
+ *
+ * @param {string} str  Valid Unicode string
+ * @return {number}     The number of Unicode characters in the string
+ */
+function strlen(str) {
+  // Call the native functions if there's no surrogate char
+  if (!hasSurrogateUnit(str)) {
+    return str.length;
+  }
+
+  let len = 0;
+  for (let pos = 0; pos < str.length; pos += getUTF16Length(str, pos)) {
+    len++;
+  }
+  return len;
+}
+
+/**
+ * Fully Unicode-enabled replacement for String#substr()
+ *
+ * @param {string} str      Valid Unicode string
+ * @param {number} start    Location in Unicode sequence to begin extracting
+ * @param {?number} length  The number of Unicode characters to extract
+ *                          (default: to the end of the string)
+ * @return {string}         Extracted sub-string
+ */
+function substr(str, start, length) {
+  start = start || 0;
+  length = (length === undefined) ? Infinity : (length || 0);
+
+  // Call the native functions if there's no surrogate char
+  if (!hasSurrogateUnit(str)) {
+    return str.substr(start, length);
+  }
+
+  // Obvious cases
+  const size = str.length;
+  if (size <= 0 || start > size || length <= 0) {
+    return '';
+  }
+
+  // Find the actual starting position
+  let posA = 0;
+  if (start > 0) {
+    for (; start > 0 && posA < size; start--) {
+      posA += getUTF16Length(str, posA);
+    }
+    if (posA >= size) {
+      return '';
+    }
+  } else if (start < 0) {
+    for (posA = size; start < 0 && 0 < posA; start++) {
+      posA -= getUTF16Length(str, posA - 1);
+    }
+    if (posA < 0) {
+      posA = 0;
+    }
+  }
+
+  // Find the actual ending position
+  let posB = size;
+  if (length < size) {
+    for (posB = posA; length > 0 && posB < size; length--) {
+      posB += getUTF16Length(str, posB);
+    }
+  }
+
+  return str.substring(posA, posB);
+}
+
+/**
+ * Fully Unicode-enabled replacement for String#substring()
+ *
+ * @param {string} str    Valid Unicode string
+ * @param {number} start  Location in Unicode sequence to begin extracting
+ * @param {?number} end   Location in Unicode sequence to end extracting
+ *                        (default: end of the string)
+ * @return {string}       Extracted sub-string
+ */
+function substring(str, start, end) {
+  start = start || 0;
+  end = (end === undefined) ? Infinity : (end || 0);
+
+  if (start < 0) {
+    start = 0;
+  }
+  if (end < 0) {
+    end = 0;
+  }
+
+  const length = Math.abs(end - start);
+  start = (start < end) ? start : end;
+  return substr(str, start, length);
+}
+
+/**
+ * Get a list of Unicode code-points from a String
+ *
+ * @param {string} str        Valid Unicode string
+ * @return {array<number>}    A list of code-points in [0..0x10FFFF]
+ */
+function getCodePoints(str) {
+  const codePoints = [];
+  for (let pos = 0; pos < str.length; pos += getUTF16Length(str, pos)) {
+    codePoints.push(str.codePointAt(pos));
+  }
+  return codePoints;
+}
+
+const UnicodeUtils = {
+  getCodePoints: getCodePoints,
+  getUTF16Length: getUTF16Length,
+  hasSurrogateUnit: hasSurrogateUnit,
+  isCodeUnitInSurrogateRange: isCodeUnitInSurrogateRange,
+  isSurrogatePair: isSurrogatePair,
+  strlen: strlen,
+  substring: substring,
+  substr: substr
+};
+
+module.exports = UnicodeUtils;

--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -1,4 +1,5 @@
 const Remarkable = require('remarkable');
+const { strlen } = require('./UnicodeUtils');
 const TRAILING_NEW_LINE = /\n$/;
 
 // Block level items, key is Remarkable's key for them, value returned is
@@ -119,14 +120,14 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
     } else if (BlockStyles[child.type]) {
       var key = generateUniqueKey();
       var styleBlock = {
-        offset: content.length || 0,
+        offset: strlen(content) || 0,
         length: 0,
         style: BlockStyles[child.type]
       };
 
       // Edge case hack because code items don't have inline content or open/close, unlike everything else
       if (child.type === 'code') {
-        styleBlock.length = child.content.length;
+        styleBlock.length = strlen(child.content);
         content += child.content;
       }
 
@@ -137,18 +138,18 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
       blockEntities[key] = BlockEntities[child.type](child);
 
       blockEntityRanges.push({
-        offset: content.length || 0,
+        offset: strlen(content) || 0,
         length: 0,
         key: key
       });
     } else if (child.type.indexOf('_close') !== -1 && BlockEntities[child.type.replace('_close', '_open')]) {
-      blockEntityRanges[blockEntityRanges.length - 1].length = content.length - blockEntityRanges[blockEntityRanges.length - 1].offset;
+      blockEntityRanges[blockEntityRanges.length - 1].length = strlen(content) - blockEntityRanges[blockEntityRanges.length - 1].offset;
     } else if (child.type.indexOf('_close') !== -1 && BlockStyles[child.type.replace('_close', '_open')]) {
       var type = BlockStyles[child.type.replace('_close', '_open')]
       blockInlineStyleRanges = blockInlineStyleRanges
         .map(style => {
           if (style.length === 0 && style.style === type) {
-            style.length = content.length - style.offset;
+            style.length = strlen(content) - style.offset;
           }
           return style;
         });

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -188,4 +188,34 @@ describe('draftToMarkdown', function () {
 
     expect(markdown).toEqual('1. item\n    1. item');
   });
+
+  it('renders emoji correctly', function () {
+    /* eslint-disable */
+    var rawObject =  {
+      'entityMap': {},
+      'blocks': [
+        {
+          'depth': 0,
+          'type': 'unstyled',
+          'text': 'Testing 👍 italic words words words bold words words words',
+          'entityRanges': [],
+          'inlineStyleRanges': [
+            {
+              'offset': 10,
+              'length': 6,
+              'style': 'ITALIC'
+            },
+            {
+              'offset': 35,
+              'length': 4,
+              'style': 'BOLD'
+            }
+          ]
+        }
+      ]
+    }
+    /* eslint-enable */
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('Testing 👍 _italic_ words words words **bold** words words words');
+  });
 });

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -302,4 +302,34 @@ describe('markdownToDraft', function () {
       ]
     });
   });
+
+  it('can handle emoji', function () {
+    // Note `'👍'.length === 2`
+    var markdown = 'Testing 👍 _italic_ words words words **bold** words words words';
+    var conversionResult = markdownToDraft(markdown);
+
+    expect(conversionResult).toEqual({
+      'entityMap': {},
+      'blocks': [
+        {
+          'depth': 0,
+          'type': 'unstyled',
+          'text': 'Testing 👍 italic words words words bold words words words',
+          'entityRanges': [],
+          'inlineStyleRanges': [
+            {
+              'offset': 10,
+              'length': 6,
+              'style': 'ITALIC'
+            },
+            {
+              'offset': 35,
+              'length': 4,
+              'style': 'BOLD'
+            }
+          ]
+        }
+      ]
+    });
+  });
 });


### PR DESCRIPTION
Hey, great project!

I discovered an issue where when you perform `markdownToDraftJS` on markdown that contains emoji, all the DraftJS inline styles become offset, e.g.:

`Testing 👍 _italic_ words words words **bold** words words words`

(`Testing \ud83d\udc4d _italic_ words words words **bold** words words words`)

becomes:

![screen shot 2018-01-22 at 12 44 39](https://user-images.githubusercontent.com/129910/35221431-0974da6a-ff72-11e7-9b89-ccb9b5f94010.png)

I've submitted this PR to fix this issue, when reviewing I recommend reviewing the commits one at a time - note that the second commit is just a direct copy from [`fbjs`'s `UnicodeUtils.js`](https://github.com/facebook/fbjs/blob/7da8335b78d669cba263760872f0a45ed16b4d12/packages/fbjs/src/unicode/UnicodeUtils.js) which I then tweak in the next commit to make any changes explicit.

I include below a longer explanation of the issue, mostly so I remember exactly how I figured all this out.

---

The reason for this issue is that DraftJS treats length of the `👍` as `1` (it is 1 character) whereas JavaScript strings treat it has having length `2` due to the surrogate pair ( `"\ud83d\udc4d".length === 2` / `"👍".length === 2`).

To see this in their tests, check out [the test for decodeInlineStyleRanges](https://github.com/facebook/draft-js/blob/14d9f527c172e64357c8154853797d2e19a46005/src/model/encoding/__tests__/decodeInlineStyleRanges-test.js#L59-L63):

```js
    text: 'Take a \uD83D\uDCF7 #selfie',
    inlineStyleRanges: [
      {offset: 4, length: 4, style: 'BOLD'},
      {offset: 6, length: 8, style: 'ITALIC'},
    ],
```


and the <a href="https://github.com/facebook/draft-js/blob/14d9f527c172e64357c8154853797d2e19a46005/src/model/encoding/__tests__/__snapshots__/decodeInlineStyleRanges-test.js.snap#L59-L100">resulting snapshot</a>:

```js
Array [
  Array [],
  Array [],
  Array [],
  Array [],
  Array [
    "BOLD",
  ],
  Array [
    "BOLD",
  ],
  Array [
    "BOLD",
    "ITALIC",
  ],
  Array [
    "BOLD",
    "ITALIC",
  ],
  Array [
    "BOLD",
    "ITALIC",
  ],
  Array [
    "ITALIC",
  ],
  Array [
    "ITALIC",
  ],
  Array [
    "ITALIC",
  ],
  Array [
    "ITALIC",
  ],
  Array [
    "ITALIC",
  ],
  Array [
    "ITALIC",
  ],
  Array [],
  Array [],
]
```

  
Here you can see that because `BOLD` and `ITALIC` both overlap the emoji, even though their lengths are 4 and 8 respectively the each affect 5 and 9 elements in the resulting array respectively.

This is because [in `decodeInlineStyleRanges`](https://github.com/facebook/draft-js/blob/14d9f527c172e64357c8154853797d2e19a46005/src/model/encoding/decodeInlineStyleRanges.js#L35-L36), they use `substr` from `UnicodeUtils` to parse the ranges.

To solve this, we need to use `strlen(content)` from `UnicodeUtils` to calculate the string lengths rather than using `content.length`. Frustratingly `UnicodeUtils` is in the `fbjs` package which explicitly says to not depend on it because it may break. For this reason (and since it's MIT licensed so shouldn't be an issue) I've copied over the one file `UnicodeUtils.js` into this project and extremely lightly edited it so it doesn't add any dependencies. I've also added a failing test to reproduce the issue which I've then made pass using `UnicodeUtils.strlen`.

