### PR TITLE
Fix handling of emoji

### DIFF
--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -188,4 +188,34 @@ describe('draftToMarkdown', function () {
 
     expect(markdown).toEqual('1. item\n    1. item');
   });
+
+  it('renders emoji correctly', function () {
+    /* eslint-disable */
+    var rawObject =  {
+      'entityMap': {},
+      'blocks': [
+        {
+          'depth': 0,
+          'type': 'unstyled',
+          'text': 'Testing 👍 italic words words words bold words words words',
+          'entityRanges': [],
+          'inlineStyleRanges': [
+            {
+              'offset': 10,
+              'length': 6,
+              'style': 'ITALIC'
+            },
+            {
+              'offset': 35,
+              'length': 4,
+              'style': 'BOLD'
+            }
+          ]
+        }
+      ]
+    }
+    /* eslint-enable */
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('Testing 👍 _italic_ words words words **bold** words words words');
+  });
 });

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -302,4 +302,34 @@ describe('markdownToDraft', function () {
       ]
     });
   });
+
+  it('can handle emoji', function () {
+    // Note `'👍'.length === 2`
+    var markdown = 'Testing 👍 _italic_ words words words **bold** words words words';
+    var conversionResult = markdownToDraft(markdown);
+
+    expect(conversionResult).toEqual({
+      'entityMap': {},
+      'blocks': [
+        {
+          'depth': 0,
+          'type': 'unstyled',
+          'text': 'Testing 👍 italic words words words bold words words words',
+          'entityRanges': [],
+          'inlineStyleRanges': [
+            {
+              'offset': 10,
+              'length': 6,
+              'style': 'ITALIC'
+            },
+            {
+              'offset': 35,
+              'length': 4,
+              'style': 'BOLD'
+            }
+          ]
+        }
+      ]
+    });
+  });
 });


### PR DESCRIPTION
See #47 for backstory.

This version uses the much simpler `Array.from` implementation to solve issues with restoring markdown styles when the markdown contains emojis.