### PR TITLE
Escape markdown characters when converting from draft to markdown

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -1,5 +1,12 @@
 const TRAILING_WHITESPACE = /[ |\u0020|\t]*$/;
 
+// This escapes some markdown but there's a few cases that are TODO -
+// - List items
+// - Back tics  (see https://github.com/Rosey/markdown-draft-js/issues/52#issuecomment-388458017)
+// - Complex markdown, like links or images. Not sure it's even worth it, because if you're typing
+// that into draft chances are you know its markdown and maybe expect it convert? :/
+const MARKDOWN_STYLE_CHARACTERS = /(\*|_|~|>|#|\\)/;
+
 // A map of draftjs block types -> markdown open and close characters
 // Both the open and close methods must exist, even if they simply return an empty string.
 // They should always return a string.
@@ -303,6 +310,7 @@ function renderBlock(block, index, rawDraftObject, options) {
       markdownToAdd = [];
     }
 
+    character = character.replace(MARKDOWN_STYLE_CHARACTERS, '\\$1');
     markdownString += character;
   });
 

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -227,4 +227,13 @@ describe('draftToMarkdown', function () {
     var markdown = draftToMarkdown(rawObject);
     expect(markdown).toEqual('Testing 👍 _italic_ words words words **bold** words words words');
   });
+
+  it ('escapes markdown characters', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"Test _not italic_ Test **not bold**","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('Test \\_not italic\\_ Test \\*\\*not bold\\*\\*');
+  });
 });

--- a/test/idempotency.spec.js
+++ b/test/idempotency.spec.js
@@ -93,4 +93,20 @@ describe('idempotency', function () {
 
     expect(markdownConversion).toEqual(markdown);
   });
+
+  it ('renders escaped italics correctly', function () {
+    var markdown = 'test \\_not italic\\_ test';
+    var rawDraftConversion = markdownToDraft(markdown);
+    var markdownConversion = draftToMarkdown(rawDraftConversion);
+
+    expect(markdownConversion).toEqual(markdown);
+  });
+
+  it ('renders escaped bold correctly', function () {
+    var markdown = 'test \\*\\*not italic\\*\\* test';
+    var rawDraftConversion = markdownToDraft(markdown);
+    var markdownConversion = draftToMarkdown(rawDraftConversion);
+
+    expect(markdownConversion).toEqual(markdown);
+  });
 });


### PR DESCRIPTION
Won't work for more complex markdown, like if you include link code in
your draft copy, but in that case I suspect you know markdown and expect
it to convert anyway.

But this will escape all the normies, like \* and \_.

Reason being someone may actually want those characters to appear as-is
if they're typing them into their draft editor.

There's a TODO in the comment to look into some of the more complicated
cases but tbh I just am too sleep deprived and busy to think about an
elegant and proper fix I am sorry 😬 I think for many people this will
be sufficient.

----

🙃 🙃 🙃 🙃 🙃 🙃 🙃 🙃 🙃 🙃 

https://github.com/Rosey/markdown-draft-js/issues/52

Very sorry for tapping out on the more complicated cases here, hoping this will tide people over until I'm not a total zombie. 