### PR TITLE
Tweak trailing whitespace regular expression

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -1,4 +1,4 @@
-const TRAILING_WHITESPACE = /[ |\u0020|\t]*$/;
+const TRAILING_WHITESPACE = /[ \u0020\t]*$/;
 
 // This escapes some markdown but there's a few cases that are TODO -
 // - List items


### PR DESCRIPTION
This is my dumb bad but the `|` is not an "or" when inside `[]` - the
"or" is implicit, e.g. all characters in a `[]` block means "one of
these". So the regular expression was actually searching for the `|`
character, which is not what we want.