### PR TITLE
Don’t apply block styles to empty blocks

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -179,6 +179,10 @@ const SingleNewlineAfterBlock = [
   'ordered-list-item'
 ];
 
+function isEmptyBlock(block) {
+  return block.text.length === 0 && block.entityRanges.length === 0 && Object.keys(block.data || {}).length === 0;
+}
+
 /**
  * Generate markdown for a single block javascript object
  * DraftJS raw object contains an array of blocks, which is the main "structure"
@@ -200,9 +204,14 @@ function renderBlock(block, index, rawDraftObject, options) {
 
   var type = block.type;
 
+  // draft-js emits empty blocks that have type set... don't style them
+  if (isEmptyBlock(block)) {
+    type = 'unstyled';
+  }
+
   // Render main block wrapping element
   if (customStyleItems[type] || StyleItems[type]) {
-    if (block.type === 'unordered-list-item' || block.type === 'ordered-list-item') {
+    if (type === 'unordered-list-item' || type === 'ordered-list-item') {
       markdownString += ' '.repeat(block.depth * 4);
     }
 

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -236,4 +236,17 @@ describe('draftToMarkdown', function () {
     var markdown = draftToMarkdown(rawObject);
     expect(markdown).toEqual('Test \\_not italic\\_ Test \\*\\*not bold\\*\\*');
   });
+
+  it('handles blank lines with styled block types', function () {
+    // draft-js can have blank lines that have block styles.
+    // This would result in double-application of markdown line prefixes.
+
+    /* eslint-disable */
+    const rawObject = { "blocks": [ { "key": "e8ojh", "text": "", "type": "header-three", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} }, { "key": "eg79g", "text": "Header 1", "type": "header-three", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} }, { "key": "123", "text": "", "type": "header-three", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} }, { "key": "456", "text": "Header 2", "type": "header-three", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} } ], "entityMap": {} };
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('### Header 1\n\n### Header 2');
+  });
+
 });


### PR DESCRIPTION
Turning on "header-3" mode in draft, then adding the following (note blank lines):

```

Header 1

Header 2
```

would convert to:

```
### ### Header 1

### ### Header 2
```

With this PR, the result is:

```
### Header 1

### Header 2
```

Not familiar at all with this codebase; hopefully I didn't introduce other errors with this change.
