### PR TITLE
Dont style empty blocks

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -179,6 +179,10 @@ const SingleNewlineAfterBlock = [
   'ordered-list-item'
 ];
 
+function isEmptyBlock(block) {
+  return block.text.length === 0 && block.entityRanges.length === 0 && Object.keys(block.data || {}).length === 0;
+}
+
 /**
  * Generate markdown for a single block javascript object
  * DraftJS raw object contains an array of blocks, which is the main "structure"
@@ -200,9 +204,14 @@ function renderBlock(block, index, rawDraftObject, options) {
 
   var type = block.type;
 
+  // draft-js emits empty blocks that have type set... don't style them
+  if (isEmptyBlock(block)) {
+    type = 'unstyled';
+  }
+
   // Render main block wrapping element
   if (customStyleItems[type] || StyleItems[type]) {
-    if (block.type === 'unordered-list-item' || block.type === 'ordered-list-item') {
+    if (type === 'unordered-list-item' || type === 'ordered-list-item') {
       markdownString += ' '.repeat(block.depth * 4);
     }
 

--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -204,8 +204,10 @@ function renderBlock(block, index, rawDraftObject, options) {
 
   var type = block.type;
 
-  // draft-js emits empty blocks that have type set... don't style them
-  if (isEmptyBlock(block)) {
+  // draft-js emits empty blocks that have type set… don’t style them unless the user wants to preserve new lines
+  // (if newlines are preserved each empty line should be "styled" eg in case of blockquote we want to see a blockquote.)
+  // but if newlines aren’t preserved then we'd end up having double or triple or etc markdown characters, which is a bug.
+  if (isEmptyBlock(block) && !options.preserveNewlines) {
     type = 'unstyled';
   }
 
@@ -351,7 +353,13 @@ function renderBlock(block, index, rawDraftObject, options) {
     markdownString += '\n';
   } else if (rawDraftObject.blocks[index + 1]) {
     if (rawDraftObject.blocks[index].text) {
-      markdownString += '\n\n';
+      if (type === 'unstyled' && options.preserveNewlines) {
+        markdownString += '\n\n';
+      } else if (!options.preserveNewlines) {
+        markdownString += '\n\n';
+      } else {
+        markdownString += '\n';
+      }
     } else if (options.preserveNewlines) {
       markdownString += '\n';
     }

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -236,4 +236,17 @@ describe('draftToMarkdown', function () {
     var markdown = draftToMarkdown(rawObject);
     expect(markdown).toEqual('Test \\_not italic\\_ Test \\*\\*not bold\\*\\*');
   });
+
+  it('handles blank lines with styled block types', function () {
+    // draft-js can have blank lines that have block styles.
+    // This would result in double-application of markdown line prefixes.
+
+    /* eslint-disable */
+    const rawObject = { "blocks": [ { "key": "e8ojh", "text": "", "type": "header-three", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} }, { "key": "eg79g", "text": "Header 1", "type": "header-three", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} }, { "key": "123", "text": "", "type": "header-three", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} }, { "key": "456", "text": "Header 2", "type": "header-three", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} } ], "entityMap": {} };
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('### Header 1\n\n### Header 2');
+  });
+
 });

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -247,6 +247,9 @@ describe('draftToMarkdown', function () {
 
     var markdown = draftToMarkdown(rawObject);
     expect(markdown).toEqual('### Header 1\n\n### Header 2');
+
+    markdown = draftToMarkdown(rawObject, {preserveNewlines: true});
+    expect(markdown).toEqual('### \n### Header 1\n### \n### Header 2');
   });
 
 });


### PR DESCRIPTION
https://github.com/Rosey/markdown-draft-js/pull/62 + an additional commit for `preserveNewLines`

There's some problems with `markdownToDraft` as outlined in https://github.com/Rosey/markdown-draft-js/issues/59 and with this change there will be additional work needed there when doing the bug fix. This idempotency test should pass, but fails:

```js
it('renders formatted new lines text correctly', function () {
    var markdownString = '> Test\n\n\n> Hello There\n> \n> \n\nSmile\n\n\n\n\n\n\n\nYep Hi';
    var draftJSObject = markdownToDraft(markdownString, {preserveNewlines: true});
    var markdownFromDraft = draftToMarkdown(draftJSObject, {preserveNewlines: true});

    expect(markdownFromDraft).toEqual(markdownString);
  });
```