### PR TITLE
Fix issue of multiline blockquotes having content stripped

### DIFF
--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -33,6 +33,17 @@ describe('markdownToDraft', function () {
       expect(conversionResult.blocks[2].type).toEqual('blockquote');
       expect(conversionResult.blocks[2].text).toEqual('Test I am a blockquote');
     });
+
+    it ('can handle empty blockquote between blockquote with content', function () {
+      var markdown = '> Testing\n> \n> \n> Hello';
+      var conversionResult = markdownToDraft(markdown);
+
+      expect(conversionResult.blocks[0].type).toEqual('blockquote');
+      expect(conversionResult.blocks[0].text).toEqual('Testing');
+
+      expect(conversionResult.blocks[1].type).toEqual('blockquote');
+      expect(conversionResult.blocks[1].text).toEqual('Hello');
+    });
   });
 
   describe('headings', function () {


### PR DESCRIPTION
Only the last item in a multi line blockquote was being reflected in
markdown to draft, due to a flaw in the `depth` check.

Consider this parsed remarkable data:

```
blockquote_open
paragraph_open
inline "Hello"
paragraph_close
paragraph_open
inline "Hi there"
paragraph_close
blockquote_close
```

draft conversion should be

blockquote -> hello
blockquote -> hi there

but instead was simply

blockquote -> hi there

because we were ignoring nested block styles and overwriting the text
content of the first blockquote with the `inline`.

This fixes by cloning whatever current block we are in if necessary.

---

https://github.com/Rosey/markdown-draft-js/issues/63