### PR TITLE
Update markdown character escape logic

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -5,7 +5,9 @@ const TRAILING_WHITESPACE = /[ \u0020\t]*$/;
 // - Back tics  (see https://github.com/Rosey/markdown-draft-js/issues/52#issuecomment-388458017)
 // - Complex markdown, like links or images. Not sure it's even worth it, because if you're typing
 // that into draft chances are you know its markdown and maybe expect it convert? :/
-const MARKDOWN_STYLE_CHARACTERS = /(\*|_|~|>|#|\\)/;
+const MARKDOWN_STYLE_CHARACTERS = /(\*|_|~|\\)/;
+
+const MARKDOWN_BLOCK_STYLE_CHARACTERS = /(>|#)/;
 
 // A map of draftjs block types -> markdown open and close characters
 // Both the open and close methods must exist, even if they simply return an empty string.
@@ -322,6 +324,11 @@ function renderBlock(block, index, rawDraftObject, options) {
     }
 
     character = character.replace(MARKDOWN_STYLE_CHARACTERS, '\\$1');
+
+    if (characterIndex === 0) {
+      character = character.replace(MARKDOWN_BLOCK_STYLE_CHARACTERS, '\\$1');
+    }
+
     markdownString += character;
   });
 

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -237,6 +237,15 @@ describe('draftToMarkdown', function () {
     expect(markdown).toEqual('Test \\_not italic\\_ Test \\*\\*not bold\\*\\*');
   });
 
+  it ('escapes block markdown characters when at start of line', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"# Test _not # italic_ Test **not bold**","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('\\# Test \\_not # italic\\_ Test \\*\\*not bold\\*\\*');
+  });
+
   it('handles blank lines with styled block types', function () {
     // draft-js can have blank lines that have block styles.
     // This would result in double-application of markdown line prefixes.


### PR DESCRIPTION
Headings and blockquotes should only be escaped if they're at the
beginning of a line.

https://github.com/Rosey/markdown-draft-js/issues/61