### PR TITLE
Further fixes to markdown escape logic on draftToMarkdown

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -7,8 +7,6 @@ const TRAILING_WHITESPACE = /[ \u0020\t]*$/;
 // that into draft chances are you know its markdown and maybe expect it convert? :/
 const MARKDOWN_STYLE_CHARACTERS = /(\*|_|~|\\)/;
 
-const MARKDOWN_BLOCK_STYLE_CHARACTERS = /(>|#)/;
-
 // A map of draftjs block types -> markdown open and close characters
 // Both the open and close methods must exist, even if they simply return an empty string.
 // They should always return a string.
@@ -323,10 +321,14 @@ function renderBlock(block, index, rawDraftObject, options) {
       markdownToAdd = [];
     }
 
+    // Escaping inline markdown characters
     character = character.replace(MARKDOWN_STYLE_CHARACTERS, '\\$1');
 
-    if (characterIndex === 0) {
-      character = character.replace(MARKDOWN_BLOCK_STYLE_CHARACTERS, '\\$1');
+    // Special escape logic for blockquotes and heading characters
+    if (characterIndex === 0 && character === '#' && block.text[1] && block.text[1] === ' ') {
+      character = character.replace('#', '\\#');
+    } else if (characterIndex === 0 && character === '>') {
+      character = character.replace('>', '\\>');
     }
 
     markdownString += character;

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -246,6 +246,24 @@ describe('draftToMarkdown', function () {
     expect(markdown).toEqual('\\# Test \\_not # italic\\_ Test \\*\\*not bold\\*\\*');
   });
 
+  it ('doesn’t escape heading markdown characters when no whitespace afterwards', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"#Test","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('#Test');
+  });
+
+  it ('does escape blockquote markdown characters when no whitespace afterwards', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":">Test","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('\\>Test');
+  });
+
   it('handles blank lines with styled block types', function () {
     // draft-js can have blank lines that have block styles.
     // This would result in double-application of markdown line prefixes.


### PR DESCRIPTION
`>` and `#` don’t need to be escaped if they aren’t immediately followed
by a whitespace character.