### PR TITLE
Don’t escape markdown characters in draftToMarkdown if inside code

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -321,14 +321,16 @@ function renderBlock(block, index, rawDraftObject, options) {
       markdownToAdd = [];
     }
 
-    // Escaping inline markdown characters
-    character = character.replace(MARKDOWN_STYLE_CHARACTERS, '\\$1');
+    if (block.type !== 'code-block' && !openInlineStyles.find((style) => style.style === 'CODE')) {
+      // Escaping inline markdown characters
+      character = character.replace(MARKDOWN_STYLE_CHARACTERS, '\\$1');
 
-    // Special escape logic for blockquotes and heading characters
-    if (characterIndex === 0 && character === '#' && block.text[1] && block.text[1] === ' ') {
-      character = character.replace('#', '\\#');
-    } else if (characterIndex === 0 && character === '>') {
-      character = character.replace('>', '\\>');
+      // Special escape logic for blockquotes and heading characters
+      if (characterIndex === 0 && character === '#' && block.text[1] && block.text[1] === ' ') {
+        character = character.replace('#', '\\#');
+      } else if (characterIndex === 0 && character === '>') {
+        character = character.replace('>', '\\>');
+      }
     }
 
     markdownString += character;

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -264,6 +264,24 @@ describe('draftToMarkdown', function () {
     expect(markdown).toEqual('\\>Test');
   });
 
+  it ('doesn’t escape markdown characters in inline code blocks', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"such special code which contains *special* chars is so important","type":"unstyled","depth":0,"inlineStyleRanges":[{'offset':5,'length':43,'style':'CODE'}],"entityRanges":[],"data":{}}]};
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('such `special code which contains *special* chars` is so important');
+  });
+
+  it ('doesn’t escape markdown characters in code blocks', function () {
+    /* eslint-disable */
+    var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"such special _code_ which contains *special* chars *wow*","type":"code-block","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
+    /* eslint-enable */
+
+    var markdown = draftToMarkdown(rawObject);
+    expect(markdown).toEqual('```\nsuch special _code_ which contains *special* chars *wow*\n```');
+  });
+
   it('handles blank lines with styled block types', function () {
     // draft-js can have blank lines that have block styles.
     // This would result in double-application of markdown line prefixes.


### PR DESCRIPTION
I noticed that @mixxt and @dino115 forked this repo and added this bug
fix which is 👍 so I’ve ripped it off to make sure the bug is fixed
here too 🙃