### PR TITLE
Disable tables when converting markdown to draft

### DIFF
--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -180,6 +180,10 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
 **/
 function markdownToDraft(string, options = {}) {
   const md = new Remarkable(options.remarkableOptions);
+  // TODO: markdownToDisable - I imagine we may want to allow users to customize this.
+  // and also a way to enable specific special markdown, as that’s another thing remarkable allows.
+  const markdownToDisable = ['table'];
+  md.block.ruler.disable(markdownToDisable);
 
   // If users want to define custom remarkable plugins for custom markdown, they can be added here
   if (options.remarkablePlugins) {

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -451,6 +451,31 @@ describe('markdownToDraft', function () {
     });
   });
 
+  it ('ignores tables', function () {
+    var markdown = 'this is the first line.\n' +
+          '\n' +
+          'this is the second line.\n' +
+          '\n' +
+          '| foo | bar |\n' +
+          '| --- | --- |\n' +
+          '| baz | bim |\n' +
+          '\n' +
+          'This is another line under the table.';
+    var conversionResult = markdownToDraft(markdown);
+
+    expect(conversionResult.blocks[0].text).toEqual('this is the first line.');
+    expect(conversionResult.blocks[0].type).toEqual('unstyled');
+
+    expect(conversionResult.blocks[1].text).toEqual('this is the second line.');
+    expect(conversionResult.blocks[1].type).toEqual('unstyled');
+
+    expect(conversionResult.blocks[2].text).toEqual('| foo | bar |\n| --- | --- |\n| baz | bim |');
+    expect(conversionResult.blocks[2].type).toEqual('unstyled');
+
+    expect(conversionResult.blocks[3].text).toEqual('This is another line under the table.');
+    expect(conversionResult.blocks[3].type).toEqual('unstyled');
+  });
+
   it('can handle emoji', function () {
     // Note `'👍'.length === 2`
     var markdown = 'Testing 👍 _italic_ words words words **bold** words words words';


### PR DESCRIPTION
DraftJS doesn’t support tables (at least not out of the box) and if we
have them turned on in markdown it creates missing blocks of text where
the table content is.

Since someone could theoretically write a DraftJS plugin to support
tables (in fact I think there is one already!) We may want to make this
an option to turn on at some point so people can write their own
entityhandler for tables in markdownToDraft/draftToMarkdown, but I
wasn’t sure what the best API for that would be so it’s just a hardcoded
value for now.