### PR TITLE
Add support for href to links

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -181,7 +181,7 @@ const EntityItems = {
     },
 
     close: function (entity) {
-      return `](${entity.data.url})`;
+      return `](${entity.data.url || entity.data.href})`;
     }
   }
 }

--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -85,7 +85,8 @@ const DefaultBlockEntities = {
       type: 'LINK',
       mutability: 'MUTABLE',
       data: {
-        url: item.href
+        url: item.href,
+        href: item.href
       }
     };
   }

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -173,9 +173,17 @@ describe('draftToMarkdown', function () {
       });
     });
 
-    it('renders links correctly', function () {
+    it('renders links with a URL correctly', function () {
       /* eslint-disable */
       var rawObject = {"entityMap":{"0":{"type":"LINK","mutability":"MUTABLE","data":{"url":"https://google.com"}},"1":{"type":"LINK","mutability":"MUTABLE","data":{"url":"https://facebook.github.io/draft-js/"}}},"blocks":[{"key":"58spd","text":"This is a test of a link","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":18,"length":6,"key":0}],"data":{}},{"key":"9ln6g","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"3euar","text":"And perhaps we should test once more.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":4,"length":7,"key":1}],"data":{}}]};
+      /* eslint-enable */
+      var markdown = draftToMarkdown(rawObject);
+      expect(markdown).toEqual('This is a test of [a link](https://google.com)\n\nAnd [perhaps](https://facebook.github.io/draft-js/) we should test once more.');
+    });
+
+    it('renders links with a HREF correctly', function () {
+      /* eslint-disable */
+      var rawObject = {"entityMap":{"0":{"type":"LINK","mutability":"MUTABLE","data":{"href":"https://google.com"}},"1":{"type":"LINK","mutability":"MUTABLE","data":{"href":"https://facebook.github.io/draft-js/"}}},"blocks":[{"key":"58spd","text":"This is a test of a link","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":18,"length":6,"key":0}],"data":{}},{"key":"9ln6g","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"3euar","text":"And perhaps we should test once more.","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":4,"length":7,"key":1}],"data":{}}]};
       /* eslint-enable */
       var markdown = draftToMarkdown(rawObject);
       expect(markdown).toEqual('This is a test of [a link](https://google.com)\n\nAnd [perhaps](https://facebook.github.io/draft-js/) we should test once more.');

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -254,6 +254,7 @@ describe('markdownToDraft', function () {
     var blockOneKey = conversionResult.blocks[0].entityRanges[0].key;
     expect(conversionResult.entityMap[blockOneKey].type).toEqual('LINK');
     expect(conversionResult.entityMap[blockOneKey].data.url).toEqual('https://google.com');
+    expect(conversionResult.entityMap[blockOneKey].data.href).toEqual('https://google.com');
 
     expect(conversionResult.blocks[1].text).toEqual('And perhaps we should test once more.');
     expect(conversionResult.blocks[1].type).toEqual('unstyled');
@@ -263,6 +264,8 @@ describe('markdownToDraft', function () {
     var blockTwoKey = conversionResult.blocks[1].entityRanges[0].key;
     expect(conversionResult.entityMap[blockTwoKey].type).toEqual('LINK');
     expect(conversionResult.entityMap[blockTwoKey].data.url).toEqual('https://facebook.github.io/draft-js/');
+    expect(conversionResult.entityMap[blockTwoKey].data.href).toEqual('https://facebook.github.io/draft-js/');
+
   });
 
   it('renders "the kitchen sink" correctly', function () {


### PR DESCRIPTION
in draft.js’s link example they use `URL` for link entities which is
what this lib was using as well, however I’ve come across some plugins
which use `href` instead, which seems like a resonable value as well.

Soooo I have added support for both values. If a user wants some other
way more custom value that doesn’t make sense I might suggest they
define their own BlockEntity and pass it in as an option (see the
README).