### PR TITLE
Add preserveMarkdown option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ var rawDraftJSObject = markdownToDraft(markdownString, {
 
 NOTE: If you plan on passing the markdown to a 3rd party markdown parser, markdown default behaviour IS to strip additional newlines, so the HTML it generates will likely strip those newlines at that point.... Which is why this is an option disabled by default.
 
-`preserveMarkdown` by default special markdown characters (i.e *~_\`) are escaped when converting from draft to markdown. Setting this option to true will prevent those special characters from being escaped, so the markdown string it gerenates will remain in its "raw" form.
+`escapeMarkdownCharacters` – by default this value is **true** and markdown characters (e.g. *~_`) typed directly into the editor by a user are escaped when converting from draft to markdown.
+
+Setting this option to **false** will prevent those special characters from being escaped, so the markdown string it generates will remain in its “raw” form. What this means is that when the markdown is later converted back to draftjs or parsed by a different markdown tool, any user-entered markdown will be rendered AS markdown, and will not "match" what the user initially entered. (So if the user explicitly typed in `**hello**`, converting to markdown and back to draft it will be restored as **hello** instead of the original `**hello**`)
 
 ### FAQ
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ var rawDraftJSObject = markdownToDraft(markdownString, {
 
 NOTE: If you plan on passing the markdown to a 3rd party markdown parser, markdown default behaviour IS to strip additional newlines, so the HTML it generates will likely strip those newlines at that point.... Which is why this is an option disabled by default.
 
+`preserveMarkdown` by default special markdown characters (i.e *~_\`) are escaped when converting from draft to markdown. Setting this option to true will prevent those special characters from being escaped, so the markdown string it gerenates will remain in its "raw" form.
+
 ### FAQ
 
 #### How do I get images to work?

--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -351,7 +351,7 @@ function renderBlock(block, index, rawDraftObject, options) {
       markdownToAdd = [];
     }
 
-    if (block.type !== 'code-block') {
+    if (block.type !== 'code-block' && !options.preserveMarkdown) {
       let insideInlineCodeStyle = openInlineStyles.find((style) => style.style === 'CODE');
 
       if (insideInlineCodeStyle) {

--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -214,7 +214,8 @@ function renderBlock(block, index, rawDraftObject, options) {
       markdownToAdd = [];
   var markdownString = '',
       customStyleItems = options.styleItems || {},
-      customEntityItems = options.entityItems || {};
+      customEntityItems = options.entityItems || {},
+      escapeMarkdownCharacters = options.hasOwnProperty('escapeMarkdownCharacters') ? options.escapeMarkdownCharacters : true;
 
   var type = block.type;
 
@@ -351,7 +352,7 @@ function renderBlock(block, index, rawDraftObject, options) {
       markdownToAdd = [];
     }
 
-    if (block.type !== 'code-block' && !options.preserveMarkdown) {
+    if (block.type !== 'code-block' && escapeMarkdownCharacters) {
       let insideInlineCodeStyle = openInlineStyles.find((style) => style.style === 'CODE');
 
       if (insideInlineCodeStyle) {

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -431,4 +431,42 @@ describe('draftToMarkdown', function () {
       expect(markdown).toEqual('```\nsuch special _code_ which contains *special* chars *wow*\n```');
     });
   });
+
+  describe('allowing markdown characters', function () {
+    it('preserves inline markdown characters', function () {
+      /* eslint-disable */
+      var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"Test _not italic_ Test **not bold**","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
+      /* eslint-enable */
+
+      var markdown = draftToMarkdown(rawObject, { preserveMarkdown: true });
+      expect(markdown).toEqual('Test _not italic_ Test **not bold**');
+    });
+
+    it('preserves block markdown characters at begining of a line', function () {
+      /* eslint-disable */
+      var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"# Test _not # italic_ Test **not bold**","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
+      /* eslint-enable */
+
+      var markdown = draftToMarkdown(rawObject, { preserveMarkdown: true });
+      expect(markdown).toEqual('# Test _not # italic_ Test **not bold**');
+    });
+
+    it('preserves blockquotes markdown characters with no trailing whitespace', function () {
+      /* eslint-disable */
+      var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":">Test","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
+      /* eslint-enable */
+
+      var markdown = draftToMarkdown(rawObject, { preserveMarkdown: true });
+      expect(markdown).toEqual('>Test');
+    });
+
+    it('preserves italics markdown characters with no trailing whitespace', function () {
+      /* eslint-disable */
+      var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"_Test_","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
+      /* eslint-enable */
+
+      var markdown = draftToMarkdown(rawObject, { preserveMarkdown: true });
+      expect(markdown).toEqual('_Test_');
+    });
+  });
 });

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -438,7 +438,7 @@ describe('draftToMarkdown', function () {
       var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"Test _not italic_ Test **not bold**","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
       /* eslint-enable */
 
-      var markdown = draftToMarkdown(rawObject, { preserveMarkdown: true });
+      var markdown = draftToMarkdown(rawObject, { escapeMarkdownCharacters: false });
       expect(markdown).toEqual('Test _not italic_ Test **not bold**');
     });
 
@@ -447,7 +447,7 @@ describe('draftToMarkdown', function () {
       var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"# Test _not # italic_ Test **not bold**","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
       /* eslint-enable */
 
-      var markdown = draftToMarkdown(rawObject, { preserveMarkdown: true });
+      var markdown = draftToMarkdown(rawObject, { escapeMarkdownCharacters: false });
       expect(markdown).toEqual('# Test _not # italic_ Test **not bold**');
     });
 
@@ -456,7 +456,7 @@ describe('draftToMarkdown', function () {
       var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":">Test","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
       /* eslint-enable */
 
-      var markdown = draftToMarkdown(rawObject, { preserveMarkdown: true });
+      var markdown = draftToMarkdown(rawObject, { escapeMarkdownCharacters: false });
       expect(markdown).toEqual('>Test');
     });
 
@@ -465,7 +465,7 @@ describe('draftToMarkdown', function () {
       var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"_Test_","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};
       /* eslint-enable */
 
-      var markdown = draftToMarkdown(rawObject, { preserveMarkdown: true });
+      var markdown = draftToMarkdown(rawObject, { escapeMarkdownCharacters: false });
       expect(markdown).toEqual('_Test_');
     });
   });


### PR DESCRIPTION
## Summary

This PR adds an option to prevent escaping special markdown characters (i.e `\*|_|~|\\|`) when converting from draft to markdown.

```js
draftToMarkdown(draftObject, {
  preserveMarkdown: true,
})
```

When `preserveMarkdown` is set to `true` the generated markdown string will be in its "raw" form, with no escaped characters. This feature is useful, in the case where saving markdown to a database is desired. 

The code changes in this PR are meant to be backwards compatible with the existing API. So the `draftToMarkdown` function will behave as normal when the `preserveMarkdown` flag is not set.

Let me know if you have any questions or concerns about these code changes.

p.s. Thanks for creating this awesome library!!:) It's been lifesaver!

## Test Plan

Run the test suite to ensure all tests pass

```
npm test
```
