### PR TITLE
Add support for passing preset with additional options to Remarkable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please note: We recommend using a polyfill (like babel-polyfill) since we're usi
 
 `draftToMarkdown` expects a [RAW Draft.js JS object](https://facebook.github.io/draft-js/docs/api-reference-data-conversion.html).
 
-It returns a string of markdown.  
+It returns a string of markdown.
 
 ```javascript
 // First, import `draftToMarkdown`
@@ -120,9 +120,24 @@ var rawDraftJSObject = markdownToDraft(markdownString, {
 });
 ```
 
+If you would like to use a preset and pass additional options to Remarkable at the same time, you can achieve that by setting `remarkableOptions` property to a two-element array:
+
+```javascript
+var rawDraftJSObject = markdownToDraft(markdownString, {
+  remarkableOptions: [
+    'full',
+    {
+      html: true,
+      linkify: true,
+      typographer: true
+    }
+  ]
+});
+```
+
 ### More options
 
-`preserveNewlines` can be passed in to preserve empty whitespace newlines. By default, markdown rules specify that blank whitespace is collapsed, but in the interest in maintaining 1:1 parity with draft appearance-wise, this option can be turned on if you like :)  
+`preserveNewlines` can be passed in to preserve empty whitespace newlines. By default, markdown rules specify that blank whitespace is collapsed, but in the interest in maintaining 1:1 parity with draft appearance-wise, this option can be turned on if you like :)
 
 NOTE: If you plan on passing the markdown to a 3rd party markdown parser, markdown default behaviour IS to strip additional newlines, so the HTML it generates will likely strip those newlines at that point.... Which is why this is an option disabled by default.
 

--- a/README.md
+++ b/README.md
@@ -110,28 +110,14 @@ var rawDraftJSObject = markdownToDraft(markdownString, {
 
 ### Remarkable options
 
-Since this module uses remarkable under the hood, you can also pass down options for the remarkable parser, simply add the property `remarkableOptions` to your options object. For example, let's say you wanted to parse html as well:
+Since this module uses Remarkable under the hood, you can also pass down preset and options for the Remarkable parser. Simply add the `remarkablePreset` or `remarkableOptions` property (or both of them) to your options object. For example, let's say you wanted to use the `commonmark` preset and parse html as well:
 
 ```javascript
 var rawDraftJSObject = markdownToDraft(markdownString, {
+  remarkablePreset: 'commonmark',
   remarkableOptions: {
     html: true
   }
-});
-```
-
-If you would like to use a preset and pass additional options to Remarkable at the same time, you can achieve that by setting `remarkableOptions` property to a two-element array:
-
-```javascript
-var rawDraftJSObject = markdownToDraft(markdownString, {
-  remarkableOptions: [
-    'full',
-    {
-      html: true,
-      linkify: true,
-      typographer: true
-    }
-  ]
 });
 ```
 

--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -180,13 +180,9 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
  * @return {Object} rawDraftObject
 **/
 function markdownToDraft(string, options = {}) {
-  let md;
-  if (Array.isArray(options.remarkableOptions) && options.remarkableOptions.length >= 2) {
-    const [preset, additionalOptions] = options.remarkableOptions;
-    md = new Remarkable(preset, additionalOptions);
-  } else {
-    md = new Remarkable(options.remarkableOptions);
-  }
+  const remarkablePreset = options.remarkablePreset || options.remarkableOptions;
+  const remarkableOptions = typeof options.remarkableOptions === 'object' ? options.remarkableOptions : null;
+  const md = new Remarkable(remarkablePreset, remarkableOptions);
 
   // TODO: markdownToDisable - I imagine we may want to allow users to customize this.
   // and also a way to enable specific special markdown, as that’s another thing remarkable allows.

--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -180,7 +180,14 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
  * @return {Object} rawDraftObject
 **/
 function markdownToDraft(string, options = {}) {
-  const md = new Remarkable(options.remarkableOptions);
+  let md;
+  if (Array.isArray(options.remarkableOptions) && options.remarkableOptions.length >= 2) {
+    const [preset, additionalOptions] = options.remarkableOptions;
+    md = new Remarkable(preset, additionalOptions);
+  } else {
+    md = new Remarkable(options.remarkableOptions);
+  }
+
   // TODO: markdownToDisable - I imagine we may want to allow users to customize this.
   // and also a way to enable specific special markdown, as that’s another thing remarkable allows.
   const markdownToDisable = ['table'];

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -9,6 +9,13 @@ describe('markdownToDraft', function () {
     expect(conversionResult.blocks[0].type).toEqual('unstyled');
   });
 
+  it('renders text according to Remarkable options', function () {
+    var markdown = '(p)';
+    var conversionResult = markdownToDraft(markdown, {remarkableOptions: ['full', {typographer: true}]});
+    expect(conversionResult.blocks[0].text).toEqual('§');
+    expect(conversionResult.blocks[0].type).toEqual('unstyled');
+  });
+
   describe('blockquotes', function () {
     it('renders blockquotes correctly', function () {
       var markdown = '> Test I am a blockquote';

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -11,7 +11,14 @@ describe('markdownToDraft', function () {
 
   it('renders text according to Remarkable options', function () {
     var markdown = '(p)';
-    var conversionResult = markdownToDraft(markdown, {remarkableOptions: ['full', {typographer: true}]});
+    var conversionResult = markdownToDraft(markdown, {remarkableOptions: {typographer: true}});
+    expect(conversionResult.blocks[0].text).toEqual('§');
+    expect(conversionResult.blocks[0].type).toEqual('unstyled');
+  });
+
+  it('renders text according to Remarkable options (with preset)', function () {
+    var markdown = '(p)';
+    var conversionResult = markdownToDraft(markdown, {remarkablePreset: 'full', remarkableOptions: {typographer: true}});
     expect(conversionResult.blocks[0].text).toEqual('§');
     expect(conversionResult.blocks[0].type).toEqual('unstyled');
   });


### PR DESCRIPTION
When using Remarkable directly, we we can pass two arguments to its constructor - the first is the template and the second is an object with additional options.

markdown-draft-js only lets us pass a single value to the `remarkableOptions`, so we need to choose whether to use a preset or an options object.

This PR makes it possible to pass both (in an array).