### PR TITLE
Add support for hr in markdown-to-draft

### DIFF
--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -233,7 +233,7 @@ function markdownToDraft(string, options = {}) {
 
       // The entity map is a master object separate from the block so just add any entities created for this block to the master object
       Object.assign(entityMap, blockEntities);
-    } else if ((itemType.indexOf('_open') !== -1 || itemType === 'fence') && BlockTypes[itemType]) {
+    } else if ((itemType.indexOf('_open') !== -1 || itemType === 'fence' || itemType === 'hr') && BlockTypes[itemType]) {
       var depth = 0;
       var block;
 

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -529,4 +529,31 @@ describe('markdownToDraft', function () {
       ]
     });
   });
+
+  it('can handle hr', function () {
+    var markdown = 'this is the first line.\n' +
+          '\n' +
+          '---\n' +
+          '\n' +
+          'this is the second line.';
+    var conversionResult = markdownToDraft(markdown, {
+      blockTypes: {
+        hr: function (_item) {
+          return {
+            type: 'HR',
+            text: ''
+          };
+        }
+      }
+    });
+
+    expect(conversionResult.blocks[0].text).toEqual('this is the first line.');
+    expect(conversionResult.blocks[0].type).toEqual('unstyled');
+
+    expect(conversionResult.blocks[1].text).toEqual('');
+    expect(conversionResult.blocks[1].type).toEqual('HR');
+
+    expect(conversionResult.blocks[2].text).toEqual('this is the second line.');
+    expect(conversionResult.blocks[2].type).toEqual('unstyled');
+  });
 });


### PR DESCRIPTION
When converting markdown to Draft.js raw object using remarkable, support the
`'hr'` block type given by remarkable, and allow the user to pass an option
`blockTypes` containing a `hr` key telling markdown-to-draft which block type
to use.

see #96