### PR TITLE
Make markdown escaping in draft-to-markdown much smarter

### DIFF
--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -404,6 +404,31 @@ describe('draftToMarkdown', function () {
       expect(markdown).toEqual('Test \\_not italic\\_ Test \\*\\*not bold\\*\\*');
     });
 
+    it('escapes complex inline markdown characters', function () {
+      /* eslint-disable */
+      var rawObject = { "entityMap": {}, "blocks": [{ "key": "dvfr1", "text": "Test _not **i** t**a**lic_ T_est **not bold** _hi_ ok **notmatching* smile!", "type": "unstyled", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} }] };
+      /* eslint-enable */
+
+      var markdown = draftToMarkdown(rawObject);
+      expect(markdown).toEqual('Test \\_not \\*\\*i\\*\\* t**a**lic\\_ T_est \\*\\*not bold\\*\\* \\_hi\\_ ok **notmatching* smile!');
+    });
+
+    it('doesn’t escape inline markdown characters in cases where they aren’t valid as markdown', function () {
+      /* eslint-disable */
+      var rawObject = { "entityMap": {}, "blocks": [{ "key": "dvfr1", "text": "Test_not italic_ Test**not bold**", "type": "unstyled", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} }] };
+      /* eslint-enable */
+
+      var markdown = draftToMarkdown(rawObject);
+      expect(markdown).toEqual('Test_not italic_ Test**not bold**');
+
+      /* eslint-disable */
+      rawObject = { "entityMap": {}, "blocks": [{ "key": "dvfr1", "text": "Test _not italic Test not bold", "type": "unstyled", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} }] };
+      /* eslint-enable */
+
+      markdown = draftToMarkdown(rawObject);
+      expect(markdown).toEqual('Test _not italic Test not bold');
+    });
+
     it ('escapes block markdown characters when at start of line', function () {
       /* eslint-disable */
       var rawObject = {"entityMap":{},"blocks":[{"key":"dvfr1","text":"# Test _not # italic_ Test **not bold**","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]};


### PR DESCRIPTION
🤮 I hate how crazy this got but maybe it's not as bad as I think...

Basically we were seeing an issue where when a user pasted a link in, the "markdown" characters were being escaped, even though they were not actually valid markdown characters because they weren't in the right context.

Like _ is a markdown character, but if there's no matching closing character, it doesn't need to be escaped.

Similarily, when a markdown character is like this: h_a_h it shouldn't be escaped because markdown dictates there needs to be whitespace.

I was hoping this issue wasn't a big deal and wanted to ignore it, but the issue with the links was too big to ignore.