### PR TITLE
Add option to enable or disable remarkable rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,32 @@ var rawDraftJSObject = markdownToDraft(markdownString, {
 });
 ```
 
+#### Enabling / Disabling rules
+
+It's possible to enable or disable specific rules. Remarkable categorizes them into three groups, every file represents a possible rule:
+
+- [Inline](https://github.com/jonschlinkert/remarkable/tree/master/lib/rules_inline) (e.g. links, bold, italic)
+- [Block](https://github.com/jonschlinkert/remarkable/tree/master/lib/rules_block) (e.g. tables, headings)
+- [Core](https://github.com/jonschlinkert/remarkable/tree/master/lib/rules_core) (e.g. automatic link conversion or abbreviations)
+
+```javascript
+var rawDraftJSObject = markdownToDraft(markdownString, {
+  remarkablePreset: 'commonmark',
+  remarkableOptions: {
+    disable: {
+      inline: ['links', 'emphasis'],
+      block: ['heading']
+    },
+    enable: {
+      block: 'table',
+      core: ['abbr']
+    }
+  }
+});
+```
+
+The `table` rule is disabled by default but could be enabled like in the example above.
+
 ### More options
 
 `preserveNewlines` can be passed in to preserve empty whitespace newlines. By default, markdown rules specify that blank whitespace is collapsed, but in the interest in maintaining 1:1 parity with draft appearance-wise, this option can be turned on if you like :)

--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -186,11 +186,31 @@ function markdownToDraft(string, options = {}) {
   const remarkableOptions = typeof options.remarkableOptions === 'object' ? options.remarkableOptions : null;
   const md = new Remarkable(remarkablePreset, remarkableOptions);
 
-  // TODO: markdownToDisable - I imagine we may want to allow users to customize this.
-  // and also a way to enable specific special markdown, as that’s another thing remarkable allows.
-  const markdownToDisable = ['table'];
-  md.block.ruler.disable(markdownToDisable);
+  // if tables are not explicitly enabled, disable them by default
+  if (
+    !remarkableOptions ||
+    !remarkableOptions.enable ||
+    !remarkableOptions.enable.block ||
+    remarkableOptions.enable.block !== 'table' ||
+    remarkableOptions.enable.block.includes('table') === false
+  ) {
+    md.block.ruler.disable('table');
+  }
 
+  // disable the specified rules
+  if (remarkableOptions && remarkableOptions.disable) {
+    for (let [key, value] of Object.entries(remarkableOptions.disable)) {
+      md[key].ruler.disable(value);
+    }
+  }
+
+  // enable the specified rules
+  if (remarkableOptions && remarkableOptions.enable) {
+    for (let [key, value] of Object.entries(remarkableOptions.enable)) {
+      md[key].ruler.enable(value);
+    }
+  }
+  
   // If users want to define custom remarkable plugins for custom markdown, they can be added here
   if (options.remarkablePlugins) {
     options.remarkablePlugins.forEach(function (plugin) {

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -475,7 +475,7 @@ describe('markdownToDraft', function () {
     });
   });
 
-  it ('ignores tables', function () {
+  it ('ignores tables by default', function () {
     var markdown = 'this is the first line.\n' +
           '\n' +
           'this is the second line.\n' +
@@ -556,4 +556,83 @@ describe('markdownToDraft', function () {
     expect(conversionResult.blocks[2].text).toEqual('this is the second line.');
     expect(conversionResult.blocks[2].type).toEqual('unstyled');
   });
+
+  it('can disable rules', () => {
+    var markdown = 'This is a test of [a link](https://google.com)';
+    var remarkableOptions = {
+      remarkableOptions: {
+        disable: {
+          inline: 'links'
+        }
+      }
+    }
+    var conversionResult = markdownToDraft(markdown, remarkableOptions);
+
+    expect(conversionResult.blocks[0].text).toEqual(
+      'This is a test of [a link](https://google.com)'
+    );
+  });
+
+  it('can enable rules', () => {
+    var markdown = 'H~2~O is a liquid.  2^10^ is 1024.';
+    var remarkableOptions = {
+      remarkableOptions: {
+        enable: {
+          inline: ['sub', 'sup']
+        }
+      }
+    }
+    var conversionResult = markdownToDraft(markdown, remarkableOptions);
+
+    expect(conversionResult.blocks[0].text).toEqual(
+      'HO is a liquid.  2 is 1024.'
+    );
+  });
+
+  it ('can enable tables with a string', function () {
+    var markdown = 'this is the first line.\n' +
+          '\n' +
+          'this is the second line.\n' +
+          '\n' +
+          '| foo | bar |\n' +
+          '| --- | --- |\n' +
+          '| baz | bim |\n' +
+          '\n' +
+          'This is another line under the table.';
+    var remarkableOptions = {
+      remarkableOptions: {
+        enable: {
+          block: 'table'
+        }
+      }
+    }
+    var conversionResult = markdownToDraft(markdown, remarkableOptions);
+    expect(conversionResult.blocks[0].text).toEqual('this is the first line.');
+    expect(conversionResult.blocks[1].text).toEqual('bim');
+    expect(conversionResult.blocks[2].text).toEqual('This is another line under the table.');
+  });
+
+  it ('can enable tables with an array', function () {
+    var markdown = 'this is the first line.\n' +
+          '\n' +
+          'this is the second line.\n' +
+          '\n' +
+          '| foo | bar |\n' +
+          '| --- | --- |\n' +
+          '| baz | bim |\n' +
+          '\n' +
+          'This is another line under the table.';
+    var remarkableOptions = {
+      remarkableOptions: {
+        enable: {
+          block: ['table']
+        }
+      }
+    }
+    var conversionResult = markdownToDraft(markdown, remarkableOptions);
+    expect(conversionResult.blocks[0].text).toEqual('this is the first line.');
+    expect(conversionResult.blocks[1].text).toEqual('bim');
+    expect(conversionResult.blocks[2].text).toEqual('This is another line under the table.');
+  });
+
 });


### PR DESCRIPTION
Hello Rosey,

after asking you a while ago in #91 about the possibility to disable single rules I finally got around to check it out and found that it's not yet possible but already marked with a todo comment in the code.

This pull request allows users to add `enable` and `disable` options to the `remarkableOptions` object, like so:

```javascript
var rawDraftJSObject = markdownToDraft(markdownString, {
  remarkablePreset: 'commonmark',
  remarkableOptions: {
    disable: {
      inline: ['links', 'emphasis'],
      block: ['heading']
    },
    enable: {
      block: 'table',
      core: ['abbr']
    }
  }
});
```

I saw that tables are disabled by default and kept that setting, unless the user enables them.

I have extended the Readme and tests appropriately, i hope they are easy enough to understand.

My added code is formatted with prettier according to your eslint rules.

Thanks
Oskar