### PR TITLE
Added double newline after styled line

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -462,7 +462,9 @@ function renderBlock(block, index, rawDraftObject, options) {
         || SingleNewlineAfterBlock.indexOf(type) !== -1
           && SingleNewlineAfterBlock.indexOf(rawDraftObject.blocks[index + 1].type) === -1) {
         markdownString += '\n\n';
-      } else if (!options.preserveNewlines) {
+      } else if (!options.preserveNewlines
+        || (rawDraftObject.blocks[index + 1] && !rawDraftObject.blocks[index + 1].text && rawDraftObject.blocks[index + 1].type === 'unstyled' && options.preserveNewlines)) {
+        // 2 newlines if not preserving OR if this block is styled but the next block is a blank newline
         markdownString += '\n\n';
       } else {
         markdownString += '\n';

--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -211,7 +211,7 @@ function markdownToDraft(string, options = {}) {
       md[key].ruler.enable(value);
     }
   }
-  
+
   // If users want to define custom remarkable plugins for custom markdown, they can be added here
   if (options.remarkablePlugins) {
     options.remarkablePlugins.forEach(function (plugin) {

--- a/test/idempotency.spec.js
+++ b/test/idempotency.spec.js
@@ -23,6 +23,14 @@ describe('idempotency', function () {
     expect(markdownFromDraft).toEqual(markdownString);
   });
 
+  it('renders new lines text correctly with styled blocks', function () {
+    var markdownString = '# Test\n\n\nHello There\n\nSmile\n\n\n\n\n\n\n\nYep Hi';
+    var draftJSObject = markdownToDraft(markdownString, {preserveNewlines: true});
+    var markdownFromDraft = draftToMarkdown(draftJSObject, {preserveNewlines: true});
+
+    expect(markdownFromDraft).toEqual(markdownString);
+  });
+
   it('renders italic text correctly', function () {
     var markdownString = '_I am italic_ …I am not italic.';
     var draftJSObject = markdownToDraft(markdownString);


### PR DESCRIPTION
This should fix the issue discussed here:
https://github.com/Rosey/markdown-draft-js/issues/59

Newlines were not working as expected after styled blocks