### PR TITLE
Preserve newlines draft

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -427,7 +427,11 @@ function renderBlock(block, index, rawDraftObject, options) {
       }
     }
 
-    markdownString += character;
+    if (character === '\n' && type === 'blockquote') {
+      markdownString += '\n> ';
+    } else {
+      markdownString += character;
+    }
   });
 
   // Close any remaining entity tags
@@ -458,7 +462,7 @@ function renderBlock(block, index, rawDraftObject, options) {
     markdownString += '\n';
   } else if (rawDraftObject.blocks[index + 1]) {
     if (rawDraftObject.blocks[index].text) {
-      if (type === 'unstyled' && options.preserveNewlines
+      if ((type === 'unstyled' || type === 'blockquote') && options.preserveNewlines
         || SingleNewlineAfterBlock.indexOf(type) !== -1
           && SingleNewlineAfterBlock.indexOf(rawDraftObject.blocks[index + 1].type) === -1) {
         markdownString += '\n\n';

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -59,6 +59,21 @@ describe('draftToMarkdown', function () {
       markdown = draftToMarkdown(rawObject, {preserveNewlines: true});
       expect(markdown).toEqual('### \n### Header 1\n### \n### Header 2');
     });
+
+    it('handles blank lines with blockquotes', function () {
+      // draft-js can have blank lines that have block styles.
+      // This would result in double-application of markdown line prefixes.
+
+      /* eslint-disable */
+      const rawObject = { "blocks": [{ "key": "eg79g", "text": "one\n\nblockquote", "type": "blockquote", "depth": 0, "inlineStyleRanges": [], "entityRanges": [], "data": {} },{"depth":0,"type":"unstyled","text":"Hello :)","entityRanges":[],"inlineStyleRanges":[]}]};
+      /* eslint-enable */
+
+      var markdown = draftToMarkdown(rawObject);
+      expect(markdown).toEqual('> one\n> \n> blockquote\n\nHello :)');
+
+      markdown = draftToMarkdown(rawObject, {preserveNewlines: true});
+      expect(markdown).toEqual('> one\n> \n> blockquote\n\nHello :)');
+    });
   });
 
   describe('entity conversion', function () {

--- a/test/idempotency.spec.js
+++ b/test/idempotency.spec.js
@@ -79,6 +79,15 @@ describe('idempotency', function () {
     expect(markdownFromDraft).toEqual(markdownString);
   });
 
+  // TODO this test should pass but markdown-to-draft doesn’t correctly create empty markdown blocks in this case currently.
+  xit('renders blockquotes with blank lines correctly', function () {
+    var markdownString = '> Hello I am Blockquote\n> more\n> \n> \n> hey';
+    var draftJSObject = markdownToDraft(markdownString);
+    var markdownFromDraft = draftToMarkdown(draftJSObject);
+
+    expect(markdownFromDraft).toEqual(markdownString);
+  });
+
   it('renders links correctly', function () {
     var markdown = 'This is a test of [a link](https://google.com)\n\nAnd [perhaps](https://facebook.github.io/draft-js/) we should test once more.';
     var rawDraftConversion = markdownToDraft(markdown);


### PR DESCRIPTION
A fairly edge case bug fix around soft newlines within block quotes... and identified another bug and wrote a test for it but not yet fixed as I got a bit stuck 🙂 Will come back to it in another PR.

