### PR TITLE
Fix inline styling with trailing newlines

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -1,4 +1,4 @@
-const TRAILING_WHITESPACE = /[ \u0020\t]*$/;
+const TRAILING_WHITESPACE = /[ \u0020\t\n]*$/;
 
 // This escapes some markdown but there's a few cases that are TODO -
 // - List items

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -18,6 +18,13 @@ describe('draftToMarkdown', function () {
 
       var markdown = draftToMarkdown(rawObject);
       expect(markdown).toEqual('Test **Bold Text** Test');
+
+      /* eslint-disable */
+      rawObject = {"blocks":[{"key":"4mmbt","text":"Test\n\nI am some bold text\nI will not be bold","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":6,"length":20,"style":"BOLD"}],"entityRanges":[],"data":{}}],"entityMap":{}};
+      /* eslint-enable */
+
+      var markdown = draftToMarkdown(rawObject);
+      expect(markdown).toEqual('Test\n\n**I am some bold text**\nI will not be bold');
     });
 
     it('renders inline styled text with trailing whitespace correctly when trailing whitespace is the last character', function () {


### PR DESCRIPTION
Draft sometimes includes trailing whitespace in bold/italic/etc text, which markdown can't handle.

We had code in place to handle tabs and spaces but not newlines. Bug wasn't surfaced initially since out of the box draft generally always creates new paragraphs instead of a soft newline. However, there are ways you can insert a soft newline so this case can happen.