### PR TITLE
Improve README with a longer yet concise usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,43 @@ import { markdownToDraft } from 'markdown-draft-js';
 var rawObject = markdownToDraft(markdownString);
 ```
 
+## Example
+
+```javascript
+[---]
+
+import { draftToMarkdown, markdownToDraft } from 'markdown-draft-js';
+import { EditorState, convertToRaw, convertFromRaw } from 'draft-js';
+
+[---]
+
+constructor(props) {
+  super(props);
+
+  // Convert input from markdown to draftjs state
+  const markdownString = this.props.markdownString;
+  const rawData = markdownToDraft(markdownString);
+  const contentState = convertFromRaw(rawData);
+  const newEditorState = EditorState.createWithContent(contentState);
+  this.state = {
+    editorState: newEditorState,
+  };
+
+  this.onChange = (editorState) => {
+    this.setState({ editorState });
+
+    // Convert draftjs state to markdown
+    const content = this.state.editorState.getCurrentContent();
+    const rawObject = convertToRaw(content);
+    const markdownString = draftToMarkdown(rawObject);
+
+    // Do something with the markdown
+  };
+}
+
+[---]
+```
+
 ## Custom Values
 
 In case you want to extend markdown’s functionality, you can. `draftToMarkdown` accepts an (optional) second `options` argument.


### PR DESCRIPTION
I wanted to add another helpful usage example to your README. It's another way that people can quickly learn how to use your **wonderful** library! 

This example is long enough to show exactly how to integrate with draft-js but short enough to not show anything unnecessary. 

This improvement was inspired by [draftjs-md-converter](https://github.com/kadikraman/draftjs-md-converter). I found their usage example most helpful, it saved me a lot of time, and I wanted you to have one too.

Thanks! ❤
