### PR TITLE
Fix format ranges spanning newlines

### DIFF
--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -96,6 +96,12 @@ describe('draftToMarkdown', function () {
       markdown = draftToMarkdown(rawObject, {preserveNewlines: true});
       expect(markdown).toEqual('> one\n> \n> blockquote\nHello :)');
     });
+
+    it('handles inline styles spanning newlines', function () {
+      const rawObject = {'blocks':[{'key':'7va97','text':'foo\nbar','type':'unstyled','depth':0,'inlineStyleRanges':[{'offset':2,'length':3,'style':'ITALIC'}],'entityRanges':[],'data':{}}],'entityMap':{}}
+      var markdown = draftToMarkdown(rawObject);
+      expect(markdown).toEqual('fo_o_\n_b_ar');
+    })
   });
 
   describe('entity conversion', function () {


### PR DESCRIPTION
Yet another small edge case bug I found: Italic text spanning a newline does not generate valid markdown.

Example:
![image](https://user-images.githubusercontent.com/524089/87174814-0b81c580-c2d8-11ea-8e69-96180acb6f83.png)
Currently, this results in markdown like this

```
fir_st
se_cond
```

Rendering this will show underscores instead of italic text.

(Interestingly, I just found that GitHub suffers under the very same issue. 😆)

To fix this, we can split all open inline style and entity ranges when hitting a `\n` character. So now, the markdown produced for this example looks as follows

```
fir_st_
_se_cond
```