### PR TITLE
Fix the number of ordered lists

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -252,6 +252,8 @@ function renderBlock(block, index, rawDraftObject, options) {
       orderedListNumber = {};
       markdownString += (customStyleItems[type] || StyleItems[type]).open(block);
     }
+  } else {
+    orderedListNumber = {};
   }
 
   // A stack to keep track of open tags


### PR DESCRIPTION
Fix the number of ordered lists when there is unstyled block between the lists

Example:
Header
1. Some list
2. Some list

Header

1. Some list
2. Some list

will be converted to

Header
1. Some list
2. Some list
Header
3. Some list
4. Some list