### PR TITLE
Render preserved new lines after list correctly

### DIFF
--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -289,6 +289,13 @@ function markdownToDraft(string, options = {}) {
 
       if (block) {
         previousBlockEndingLine = item.lines[1];
+        // reserve one line after list block
+        if (
+          block.type === 'unordered-list-item' ||
+          block.type === 'ordered-list-item'
+        ) {
+          previousBlockEndingLine += 1;
+        }
         blocks.push(block);
       }
     }

--- a/test/idempotency.spec.js
+++ b/test/idempotency.spec.js
@@ -43,6 +43,14 @@ describe('idempotency', function () {
     expect(markdownFromDraft).toEqual(markdownString);
   });
 
+  it ('renders preserved new lines after list correctly', function () {
+    var markdown = '- unordered item\n\n\n1. ordered item\n\n\nparagraph'
+    var rawDraftConversion = markdownToDraft(markdown, {preserveNewlines: true });
+    var markdownConversion = draftToMarkdown(rawDraftConversion, {preserveNewlines: true});
+
+    expect(markdownConversion).toEqual(markdown);
+  });
+
   it('renders blockquotes correctly', function () {
     var markdownString = '> Hello I am Blockquote\n\nI am not\n\n> I am';
     var draftJSObject = markdownToDraft(markdownString, {preserveNewlines: true});


### PR DESCRIPTION
Found an issue in my editor after sending form (serialize->deseriaize)
newlines after lists are increased.