### PR TITLE
ISSUE 156: Strikethrough conversion is incomplete

### DIFF
--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -98,7 +98,8 @@ const DefaultBlockEntities = {
 const DefaultBlockStyles = {
   strong_open: 'BOLD',
   em_open: 'ITALIC',
-  code: 'CODE'
+  code: 'CODE',
+  del_open: 'STRIKETHROUGH'
 };
 
 // Key generator for entityMap items

--- a/test/draft-to-markdown.spec.js
+++ b/test/draft-to-markdown.spec.js
@@ -208,6 +208,15 @@ describe('draftToMarkdown', function () {
 
         expect(markdown).toEqual('Hello There, _I am italic_ yay');
       });
+
+      it ('renders strikethrough text correctly', function () {
+        /* eslint-disable */
+        var rawObject = {"entityMap":{},"blocks":[{"depth":0,"type":"unstyled","text":"this is strikethrough text","entityRanges":[],"inlineStyleRanges":[{"offset":8,"length":14,"style":"STRIKETHROUGH"}]}]};
+        /* eslint-enable */
+        var markdown = draftToMarkdown(rawObject);
+
+        expect(markdown).toEqual('this is ~~strikethrough~~ text');
+      });
     });
 
     it('renders links with a URL correctly', function () {

--- a/test/markdown-to-draft.spec.js
+++ b/test/markdown-to-draft.spec.js
@@ -660,4 +660,13 @@ describe('markdownToDraft', function () {
     expect(conversionResult.blocks[2].text).toEqual('This is another line under the table.');
   });
 
+  it ('can handle strikethrough', function () {
+    var markdown = 'this is ~~strikethrough~~ text';
+    var conversionResult = markdownToDraft(markdown);
+
+    expect(conversionResult.blocks[0].inlineStyleRanges.length).toBe(1);
+    expect(conversionResult.blocks[0].inlineStyleRanges[0].length).toBe(13);
+    expect(conversionResult.blocks[0].inlineStyleRanges[0].style).toBe('STRIKETHROUGH');
+  });
+
 });


### PR DESCRIPTION
https://github.com/Rosey/markdown-draft-js/issues/156

Adding support for creating DraftJS inline style for strikethrough.

Adding tests for conversion of strikethrough to and from markdown.