### PR TITLE
fix: allowing sup/sub to be equal as "code"

### DIFF
--- a/src/markdown-to-draft.js
+++ b/src/markdown-to-draft.js
@@ -142,7 +142,9 @@ function parseInline(inlineItem, BlockEntities, BlockStyles) {
       };
 
       // Edge case hack because code items don't have inline content or open/close, unlike everything else
-      if (child.type === 'code') {
+      const childTypesAllowed = ['code', 'sup', 'sub'];
+      
+      if (childTypesAllowed.includes(child.type)) {
         styleBlock.length = strlen(child.content);
         content += child.content;
       }


### PR DESCRIPTION
Seems when we use `sup` or `sub` blockStyles are returning blockStyle with `length: 0` and as code, they don't have `_open/_close`. Adding this code below, it works fine