### PR TITLE
Add support for superscript and subscript

### DIFF
--- a/src/draft-to-markdown.js
+++ b/src/draft-to-markdown.js
@@ -166,6 +166,24 @@ const StyleItems = {
     close: function () {
       return '`';
     }
+  },
+  'SUPERSCRIPT': {
+    open: function () {
+      return '`^';
+    },
+
+    close: function () {
+      return '^';
+    }
+  },
+  'SUBSCRIPT': {
+    open: function () {
+      return '~';
+    },
+
+    close: function () {
+      return '~';
+    }
   }
 };
 


### PR DESCRIPTION
**Purpose**

- To add support for SUPERSCRIPT AND SUBSCRIPT when exporting to markdown from draftjs editor state